### PR TITLE
Add datetime to targeted fixer filename

### DIFF
--- a/targeted_corruption_fixer.py
+++ b/targeted_corruption_fixer.py
@@ -17,7 +17,7 @@ import ast
 from datetime import datetime
 
 # Set up logging
-timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")[:-3]  # Include milliseconds (3 digits)
 log_filename = f"targeted_fixer_{timestamp}.log"
 
 logging.basicConfig(


### PR DESCRIPTION
Add datetime to `targeted_fixer` log filenames to prevent overwriting and enable better tracking.

---
<a href="https://cursor.com/background-agent?bcId=bc-075118ad-0150-4337-8db3-50facf74c9b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-075118ad-0150-4337-8db3-50facf74c9b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

