### PR TITLE
Centralize and standardize log outputs

### DIFF
--- a/CENTRALIZED_LOGGING_GUIDE.md
+++ b/CENTRALIZED_LOGGING_GUIDE.md
@@ -1,0 +1,181 @@
+# Centralized Logging System Guide
+
+## Overview
+
+The Ares project now uses a centralized logging system that ensures:
+1. **All log outputs are in the `log/` directory**
+2. **Each run has a centralized log file with datetime in filename**
+3. **Consistent logging format across all modules**
+4. **Proper log rotation and management**
+
+## Key Features
+
+### ✅ Centralized Configuration
+- Single point of configuration for all logging
+- Consistent formatting across all modules
+- Thread-safe logging operations
+
+### ✅ Organized Log Files
+- All logs go to the `log/` directory
+- Main log file: `ares_run_YYYYMMDD_HHMMSS.log`
+- Module-specific logs: `ares_<module>_<suffix>_YYYYMMDD_HHMMSS.log`
+- Automatic log rotation (10MB main, 5MB module-specific)
+
+### ✅ Run-based Logging
+- Each application run gets a unique timestamp-based ID
+- All logs for a run are grouped by timestamp
+- Easy to track and correlate logs from the same execution
+
+## Usage
+
+### Basic Usage
+
+```python
+from centralized_logging import get_logger
+
+# Get a logger for your module
+logger = get_logger(__name__)
+
+# Use the logger
+logger.info("This is an info message")
+logger.warning("This is a warning")
+logger.error("This is an error")
+logger.debug("This is a debug message")
+```
+
+### Module-Specific Logging
+
+For modules that need their own dedicated log files:
+
+```python
+from centralized_logging import add_module_logger
+
+# Create a module-specific logger with dedicated log file
+module_logger = add_module_logger("my_module", "validation")
+module_logger.info("This goes to a separate log file")
+```
+
+### Getting Run Information
+
+```python
+from centralized_logging import get_run_id, get_log_file_path
+
+# Get current run ID
+run_id = get_run_id()  # e.g., "20250904_151526"
+
+# Get main log file path
+log_path = get_log_file_path()  # e.g., "log/ares_run_20250904_151526.log"
+```
+
+### Setting Log Level
+
+```python
+from centralized_logging import set_log_level
+import logging
+
+# Set to debug level for more verbose logging
+set_log_level(logging.DEBUG)
+```
+
+## Migration from Old Logging
+
+### Before (Old Way)
+```python
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[
+        logging.FileHandler("my_module.log"),  # ❌ Scattered files
+        logging.StreamHandler(sys.stdout),
+    ],
+)
+logger = logging.getLogger("MyModule")
+```
+
+### After (New Way)
+```python
+from centralized_logging import get_logger
+
+logger = get_logger(__name__)  # ✅ Centralized, organized
+```
+
+## Log File Structure
+
+```
+log/
+├── ares_run_20250904_151526.log              # Main centralized log
+├── ares_analysis_validation_20250904_151526.log  # Module-specific log
+├── ares_data_quality_20250904_151526.log     # Another module log
+└── ... (other historical logs)
+```
+
+## Log Format
+
+All logs use a consistent format:
+```
+YYYY-MM-DD HH:MM:SS - <logger_name> - <level> - <message>
+```
+
+Example:
+```
+2025-09-04 15:15:26 - __main__ - INFO - Testing centralized logging system
+2025-09-04 15:15:26 - module1 - WARNING - This is a warning message
+```
+
+## Benefits
+
+1. **Organization**: All logs in one place (`log/` directory)
+2. **Traceability**: Each run has a unique timestamp-based ID
+3. **Consistency**: Same format across all modules
+4. **Maintenance**: Centralized configuration makes updates easy
+5. **Performance**: Automatic log rotation prevents disk space issues
+6. **Debugging**: Easy to correlate logs from the same execution
+
+## Files Updated
+
+The following files have been updated to use the centralized logging system:
+
+- `comprehensive_analysis_demo.py`
+- `comprehensive_analysis_core.py`
+- `comprehensive_quality_auditor.py`
+- `comprehensive_analysis_simplified.py`
+- `comprehensive_professional_analysis.py`
+- `data_quality/simple_quality_orchestrator.py`
+- `crypto_analysis/data_analyzer.py`
+- `crypto_analysis/data_downloader.py`
+
+## Implementation Details
+
+The centralized logging system is implemented in `centralized_logging.py` and provides:
+
+- **Singleton pattern**: Ensures only one logging configuration per run
+- **Thread safety**: Safe for concurrent logging operations
+- **Automatic initialization**: Logging is set up on first import
+- **Flexible configuration**: Supports both basic and module-specific logging
+- **Log rotation**: Prevents log files from growing too large
+
+## Best Practices
+
+1. **Always use `get_logger(__name__)`** for module-specific loggers
+2. **Use module-specific loggers** only when you need separate log files
+3. **Don't configure logging manually** - let the centralized system handle it
+4. **Use appropriate log levels** (DEBUG, INFO, WARNING, ERROR)
+5. **Include context in log messages** for better debugging
+
+## Troubleshooting
+
+### Logs not appearing in log/ directory
+- Ensure you're using `get_logger(__name__)` from `centralized_logging`
+- Check that the `log/` directory exists and is writable
+
+### Multiple log files for same run
+- This is normal for module-specific loggers
+- The main log file contains all messages
+- Module-specific files contain only messages from that module
+
+### Log rotation issues
+- Logs are automatically rotated when they reach size limits
+- Old logs are kept as `.1`, `.2`, etc. files
+- Check disk space if rotation seems to be failing

--- a/centralized_logging.py
+++ b/centralized_logging.py
@@ -1,0 +1,244 @@
+"""
+Centralized Logging System for Ares Project
+
+This module provides a centralized logging configuration that ensures:
+1. All log outputs are in the log/ directory
+2. Each run has a centralized log file with datetime in filename
+3. Consistent logging format across all modules
+4. Proper log rotation and management
+"""
+
+import logging
+import logging.handlers
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Dict, Any
+import threading
+
+
+class CentralizedLogger:
+    """
+    Centralized logging system that manages all logging across the application.
+    
+    Features:
+    - Single log file per run with datetime in filename
+    - All logs go to log/ directory
+    - Consistent formatting
+    - Thread-safe logging
+    - Automatic log rotation
+    """
+    
+    _instance = None
+    _lock = threading.Lock()
+    _run_id = None
+    _log_dir = None
+    _main_logger = None
+    _configured = False
+    
+    def __new__(cls):
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super(CentralizedLogger, cls).__new__(cls)
+        return cls._instance
+    
+    def __init__(self):
+        if not self._configured:
+            self._setup_logging()
+    
+    def _setup_logging(self):
+        """Initialize the centralized logging system."""
+        # Create run ID with timestamp
+        if self._run_id is None:
+            self._run_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+        
+        # Ensure log directory exists
+        self._log_dir = Path("log")
+        self._log_dir.mkdir(exist_ok=True)
+        
+        # Create main log file path
+        main_log_file = self._log_dir / f"ares_run_{self._run_id}.log"
+        
+        # Configure root logger
+        self._main_logger = logging.getLogger()
+        self._main_logger.setLevel(logging.INFO)
+        
+        # Clear any existing handlers
+        self._main_logger.handlers.clear()
+        
+        # Create formatter
+        formatter = logging.Formatter(
+            fmt="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S"
+        )
+        
+        # File handler with rotation
+        file_handler = logging.handlers.RotatingFileHandler(
+            main_log_file,
+            maxBytes=10*1024*1024,  # 10MB
+            backupCount=5,
+            encoding='utf-8'
+        )
+        file_handler.setLevel(logging.INFO)
+        file_handler.setFormatter(formatter)
+        
+        # Console handler
+        console_handler = logging.StreamHandler(sys.stdout)
+        console_handler.setLevel(logging.INFO)
+        console_handler.setFormatter(formatter)
+        
+        # Add handlers to root logger
+        self._main_logger.addHandler(file_handler)
+        self._main_logger.addHandler(console_handler)
+        
+        # Log initialization
+        self._main_logger.info(f"Centralized logging initialized - Run ID: {self._run_id}")
+        self._main_logger.info(f"Main log file: {main_log_file}")
+        
+        self._configured = True
+    
+    def get_logger(self, name: str) -> logging.Logger:
+        """
+        Get a logger instance for a specific module.
+        
+        Args:
+            name: Logger name (typically __name__ of the calling module)
+            
+        Returns:
+            Configured logger instance
+        """
+        if not self._configured:
+            self._setup_logging()
+        
+        logger = logging.getLogger(name)
+        return logger
+    
+    def get_run_id(self) -> str:
+        """Get the current run ID."""
+        return self._run_id
+    
+    def get_log_file_path(self) -> Path:
+        """Get the path to the main log file."""
+        return self._log_dir / f"ares_run_{self._run_id}.log"
+    
+    def set_level(self, level: int):
+        """
+        Set the logging level for all handlers.
+        
+        Args:
+            level: Logging level (e.g., logging.DEBUG, logging.INFO)
+        """
+        if not self._configured:
+            self._setup_logging()
+        
+        self._main_logger.setLevel(level)
+        for handler in self._main_logger.handlers:
+            handler.setLevel(level)
+    
+    def add_module_logger(self, module_name: str, log_file_suffix: Optional[str] = None) -> logging.Logger:
+        """
+        Create a module-specific logger with its own log file.
+        
+        Args:
+            module_name: Name of the module
+            log_file_suffix: Optional suffix for the log file name
+            
+        Returns:
+            Logger instance with dedicated log file
+        """
+        if not self._configured:
+            self._setup_logging()
+        
+        # Create module-specific logger
+        logger = logging.getLogger(module_name)
+        
+        # Create module-specific log file
+        if log_file_suffix:
+            log_filename = f"ares_{module_name}_{log_file_suffix}_{self._run_id}.log"
+        else:
+            log_filename = f"ares_{module_name}_{self._run_id}.log"
+        
+        log_file_path = self._log_dir / log_filename
+        
+        # Create file handler for this module
+        file_handler = logging.handlers.RotatingFileHandler(
+            log_file_path,
+            maxBytes=5*1024*1024,  # 5MB
+            backupCount=3,
+            encoding='utf-8'
+        )
+        file_handler.setLevel(logging.INFO)
+        
+        # Use same formatter as main logger
+        formatter = logging.Formatter(
+            fmt="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S"
+        )
+        file_handler.setFormatter(formatter)
+        
+        # Add handler to module logger
+        logger.addHandler(file_handler)
+        logger.setLevel(logging.INFO)
+        
+        # Log the creation
+        logger.info(f"Module logger created - Log file: {log_file_path}")
+        
+        return logger
+
+
+# Global instance
+_centralized_logger = CentralizedLogger()
+
+
+def get_logger(name: str) -> logging.Logger:
+    """
+    Convenience function to get a logger instance.
+    
+    Args:
+        name: Logger name (typically __name__ of the calling module)
+        
+    Returns:
+        Configured logger instance
+    """
+    return _centralized_logger.get_logger(name)
+
+
+def get_run_id() -> str:
+    """Get the current run ID."""
+    return _centralized_logger.get_run_id()
+
+
+def get_log_file_path() -> Path:
+    """Get the path to the main log file."""
+    return _centralized_logger.get_log_file_path()
+
+
+def set_log_level(level: int):
+    """
+    Set the logging level for all handlers.
+    
+    Args:
+        level: Logging level (e.g., logging.DEBUG, logging.INFO)
+    """
+    _centralized_logger.set_level(level)
+
+
+def add_module_logger(module_name: str, log_file_suffix: Optional[str] = None) -> logging.Logger:
+    """
+    Create a module-specific logger with its own log file.
+    
+    Args:
+        module_name: Name of the module
+        log_file_suffix: Optional suffix for the log file name
+        
+    Returns:
+        Logger instance with dedicated log file
+    """
+    return _centralized_logger.add_module_logger(module_name, log_file_suffix)
+
+
+# Initialize logging on import
+if not _centralized_logger._configured:
+    _centralized_logger._setup_logging()

--- a/comprehensive_analysis_core.py
+++ b/comprehensive_analysis_core.py
@@ -18,7 +18,6 @@ Provides:
 
 import argparse
 import json
-import logging
 import os
 import sys
 import time
@@ -26,6 +25,8 @@ from collections import Counter, defaultdict
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
+
+from centralized_logging import get_logger
 
 # Import minimal modules
 from minimal_config import get_default_config as get_default_config_minimal_config
@@ -43,16 +44,7 @@ except ImportError as e:
     print(f"Warning: Some analyzers not available: {e}")
     ANALYZERS_AVAILABLE = False
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    handlers=[
-        logging.FileHandler("comprehensive_analysis_core.log"),
-        logging.StreamHandler(sys.stdout),
-    ],
-)
-logger = logging.getLogger("ComprehensiveAnalysisCore")
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/comprehensive_analysis_demo.py
+++ b/comprehensive_analysis_demo.py
@@ -8,8 +8,6 @@ import argparse
 import ast
 import json
 
-# Configure logging
-import logging
 import os
 import sys
 import time
@@ -18,15 +16,9 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    handlers=[
-        logging.FileHandler("comprehensive_analysis_demo.log"),
-        logging.StreamHandler(sys.stdout),
-    ],
-)
-logger = logging.getLogger("ComprehensiveAnalysisDemo")
+from centralized_logging import get_logger
+
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/comprehensive_analysis_simplified.py
+++ b/comprehensive_analysis_simplified.py
@@ -25,7 +25,6 @@ Provides:
 
 import argparse
 import json
-import logging
 import os
 import sys
 import time
@@ -33,6 +32,8 @@ from collections import Counter, defaultdict
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
+
+from centralized_logging import get_logger
 
 # Import minimal modules
 from minimal_config import get_default_config as get_default_config_minimal_config
@@ -60,16 +61,7 @@ except ImportError as e:
     print(f"Warning: Some analyzers not available: {e}")
     ANALYZERS_AVAILABLE = False
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    handlers=[
-        logging.FileHandler("comprehensive_analysis_simplified.log"),
-        logging.StreamHandler(sys.stdout),
-    ],
-)
-logger = logging.getLogger("ComprehensiveAnalysisSimplified")
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/comprehensive_professional_analysis.py
+++ b/comprehensive_professional_analysis.py
@@ -16,7 +16,6 @@ Provides:
 
 import argparse
 import json
-import logging
 import os
 import sys
 import time
@@ -24,6 +23,8 @@ from collections import Counter, defaultdict
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
+
+from centralized_logging import get_logger
 
 # Add code_quality to path
 code_quality_path = Path(__file__).parent / "code_quality"
@@ -52,16 +53,7 @@ except ImportError as e:
     print(f"Warning: Code quality tools not available: {e}")
     CODE_QUALITY_AVAILABLE = False
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    handlers=[
-        logging.FileHandler("comprehensive_analysis.log"),
-        logging.StreamHandler(sys.stdout),
-    ],
-)
-logger = logging.getLogger("ComprehensiveProfessionalAnalysis")
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/comprehensive_quality_auditor.py
+++ b/comprehensive_quality_auditor.py
@@ -19,7 +19,6 @@ Usage:
 import argparse
 import csv
 import json
-import logging
 import sys
 import time
 from collections import defaultdict
@@ -27,16 +26,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    handlers=[
-        logging.FileHandler("quality_audit.log"),
-        logging.StreamHandler(sys.stdout),
-    ],
-)
-logger = logging.getLogger("ComprehensiveQualityAuditor")
+from centralized_logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class QualityLevel:

--- a/crypto_analysis/data_analyzer.py
+++ b/crypto_analysis/data_analyzer.py
@@ -4,7 +4,6 @@ Cryptocurrency Price Movement Analyzer
 Analyzes OHLCV data to calculate potential profits from different triple barrier methods
 """
 
-import logging
 import warnings
 from pathlib import Path
 
@@ -13,18 +12,11 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 
+from centralized_logging import get_logger
+
 warnings.filterwarnings("ignore")
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    handlers=[
-        logging.FileHandler("analysis.log"),
-        logging.StreamHandler(),
-    ],
-)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 class CryptoPriceAnalyzer:
     def __init__(self, data_file):

--- a/crypto_analysis/data_downloader.py
+++ b/crypto_analysis/data_downloader.py
@@ -4,7 +4,6 @@ Cryptocurrency Data Downloader for Scalping/Swinging Analysis
 Downloads 15-minute klines from Binance for multiple assets over 2 years
 """
 
-import logging
 import time
 import warnings
 from datetime import datetime, timedelta
@@ -13,18 +12,11 @@ from pathlib import Path
 import pandas as pd
 import requests
 
+from centralized_logging import get_logger
+
 warnings.filterwarnings("ignore")
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    handlers=[
-        logging.FileHandler("data_download.log"),
-        logging.StreamHandler(),
-    ],
-)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 class BinanceDataDownloader:
     def __init__(self):

--- a/data_quality/simple_quality_orchestrator.py
+++ b/data_quality/simple_quality_orchestrator.py
@@ -9,14 +9,13 @@ JSON and CSV files without requiring pandas or sklearn.
 import argparse
 import csv
 import json
-import logging
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-# Configure basic logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-logger = logging.getLogger("SimpleQualityOrchestrator")
+from centralized_logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class QualityLevel:

--- a/log/ares_run_20250904_151526.log
+++ b/log/ares_run_20250904_151526.log
@@ -1,0 +1,15 @@
+2025-09-04 15:15:26 - root - INFO - Centralized logging initialized - Run ID: 20250904_151526
+2025-09-04 15:15:26 - root - INFO - Main log file: log/ares_run_20250904_151526.log
+2025-09-04 15:15:26 - __main__ - INFO - Testing centralized logging system
+2025-09-04 15:15:26 - __main__ - WARNING - This is a warning message
+2025-09-04 15:15:26 - __main__ - ERROR - This is an error message
+2025-09-04 15:15:26 - test_module - INFO - Module logger created - Log file: log/ares_test_module_validation_20250904_151526.log
+2025-09-04 15:15:26 - test_module - INFO - This message goes to the module-specific log file
+2025-09-04 15:15:26 - test_module - WARNING - Module-specific warning
+2025-09-04 15:15:26 - test_module - ERROR - Module-specific error
+2025-09-04 15:15:26 - module1 - INFO - Message from module 1
+2025-09-04 15:15:26 - module2 - INFO - Message from module 2
+2025-09-04 15:15:26 - module3 - INFO - Message from module 3
+2025-09-04 15:15:27 - module1 - WARNING - Warning from module 1
+2025-09-04 15:15:27 - module2 - ERROR - Error from module 2
+2025-09-04 15:15:27 - module3 - INFO - Another message from module 3

--- a/log/ares_test_module_validation_20250904_151526.log
+++ b/log/ares_test_module_validation_20250904_151526.log
@@ -1,0 +1,4 @@
+2025-09-04 15:15:26 - test_module - INFO - Module logger created - Log file: log/ares_test_module_validation_20250904_151526.log
+2025-09-04 15:15:26 - test_module - INFO - This message goes to the module-specific log file
+2025-09-04 15:15:26 - test_module - WARNING - Module-specific warning
+2025-09-04 15:15:26 - test_module - ERROR - Module-specific error


### PR DESCRIPTION
Centralize the logging system to ensure all outputs are in the `log/` directory, each run has a centralized log file, and all log filenames include a datetime.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5841e86-5091-49dd-a870-b801abd76cdf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d5841e86-5091-49dd-a870-b801abd76cdf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

