### PR TITLE
Fix critical syntax errors in project files

### DIFF
--- a/src/paper_trader.py
+++ b/src/paper_trader.py
@@ -43,7 +43,6 @@ class ExecutionMode(Enum):
 
 
 from src.utils.warning_symbols import (
-from src.core.decorators.errors import handles_errors
     execution_error,
     initialization_error,
     invalid,

--- a/src/tactician/sr_levels/sr_weight_optimizer.py
+++ b/src/tactician/sr_levels/sr_weight_optimizer.py
@@ -23,7 +23,6 @@ from src.tactician.sr_breakout_predictor import (
 )
 from src.utils.logger import system_logger
 from src.utils.warning_symbols import (
-from src.core.decorators.errors import handles_errors
     failed,
     invalid,
     warning,

--- a/src/training/steps/data_collection/data_preparation/step01_5_data_converter_wrapper.py
+++ b/src/training/steps/data_collection/data_preparation/step01_5_data_converter_wrapper.py
@@ -34,7 +34,6 @@ class DataConverterStep(BaseStep):
     ) -> Dict[str, Any]:
         # Defer to the existing conversion entrypoint and then expose standard outputs
         from src.training.steps.data_preparation.step01_5_data_converter import (
-from src.core.decorators.errors import handles_errors
             run_step as run_step_15,
             UnifiedDataConverter,
         )

--- a/src/training/steps/market_analysis/step1/data_gap_detector.py
+++ b/src/training/steps/market_analysis/step1/data_gap_detector.py
@@ -35,7 +35,6 @@ class DataGapDetector:
         # Import the gap filler for immediate gap filling
         try:
             from .missing_data_downloader_and_gap_filler import (
-from src.core.decorators.errors import handles_errors
                 MissingDataDownloaderAndGapFiller,
             )
             self.gap_filler = MissingDataDownloaderAndGapFiller(data_cache_path)

--- a/src/training/steps/market_analysis/step1/data_resampler.py
+++ b/src/training/steps/market_analysis/step1/data_resampler.py
@@ -25,7 +25,6 @@ project_root = Path(__file__).parent.parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 from src.core.domain import (
-from src.core.decorators.errors import handles_errors
     ValidationLevel,
     comprehensive_data_validation,
     guard_dataframe_nulls,

--- a/src/training/steps/model_training/step13_analyst_ensemble_creation.py
+++ b/src/training/steps/model_training/step13_analyst_ensemble_creation.py
@@ -160,7 +160,6 @@ class AnalystEnsembleCreationStep:
                 import datetime as datetime
                 import os
                 from src.training.optimized_feature_selection_manager import (
-from src.core.decorators.errors import handles_errors
                     OptimizedFeatureSelectionManager,
                 )
 


### PR DESCRIPTION
Remove misplaced `from src.core.decorators.errors import handles_errors` statements to fix critical syntax errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-09d75fd9-7ae5-4fa2-af38-ca3b2ad316e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09d75fd9-7ae5-4fa2-af38-ca3b2ad316e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

