### PR TITLE
Fix critical syntax errors

### DIFF
--- a/src/exchange/binance.py
+++ b/src/exchange/binance.py
@@ -14,7 +14,6 @@ import aiohttp
 
 from src.utils.logger import system_logger
 from src.utils.warning_symbols import (
-from src.core.decorators.errors import handles_errors
     connection_error,
     error,
     failed,

--- a/src/interfaces/enhanced_event_bus.py
+++ b/src/interfaces/enhanced_event_bus.py
@@ -21,7 +21,6 @@ from src.core.domain import (
 from copy import copy
 from src.utils.logger import system_logger
 from src.utils.warning_symbols import (
-from src.core.decorators.errors import handles_errors
     error,
     failed,
     initialization_error,

--- a/src/launcher/enhanced_trading_launcher.py
+++ b/src/launcher/enhanced_trading_launcher.py
@@ -162,7 +162,6 @@ class EnhancedTradingLauncher:
             if self.enable_backtesting:
                 try:
                     from src.backtesting.enhanced_backtester import (
-from src.core.decorators.errors import handles_errors
                         setup_enhanced_backtester as _setup_backtester,
                     )
                     self.enhanced_backtester = await _setup_backtester(self.config)

--- a/src/tactician/position_closing.py
+++ b/src/tactician/position_closing.py
@@ -15,7 +15,6 @@ import asyncio
 
 from src.utils.logger import system_logger
 from src.utils.warning_symbols import (
-from src.core.decorators.errors import handles_errors
     failed,
     invalid,
 )

--- a/src/training/model_trainer.py
+++ b/src/training/model_trainer.py
@@ -323,7 +323,6 @@ class RayModelTrainer:
                 if do_hpo:
                     try:
                         from src.training.steps.validation.step17_final_parameters_optimization.optimized_optuna_optimization import (
-from src.core.decorators.errors import handles_errors
                             AdvancedOptunaManager,
                         )
                     except Exception as e:  # ImportError or dependency issues

--- a/src/training/progress_manager.py
+++ b/src/training/progress_manager.py
@@ -15,7 +15,6 @@ from typing import Any
 
 from src.utils.logger import system_logger
 from src.utils.warning_symbols import (
-from src.core.decorators.errors import handles_errors
     failed,
 )
 

--- a/src/training/wavelet_caching_workflow.py
+++ b/src/training/wavelet_caching_workflow.py
@@ -239,7 +239,6 @@ async def step4_cache_management(config: dict) -> bool | None:
         logger = system_logger.getChild("WaveletWorkflow")
         # Initialize cache management
         from src.training.steps.vectorized_advanced_feature_engineering import (
-from src.core.decorators.errors import handles_errors
             WaveletFeatureCache,
         )
 

--- a/src/utils/data_access_protection.py
+++ b/src/utils/data_access_protection.py
@@ -23,7 +23,6 @@ import numpy as np
 from src.core.decorators import handles_errors, validates, log_call, traced, authenticated, requires_permission
 from .logger import system_logger
 from .common_operations import (
-from src.core.decorators.errors import handles_errors
     safe_file_exists, safe_json_dump, safe_json_load, validate_dataframe_schema,
     validate_data_quality, safe_copy, generate_hash
 )

--- a/src/utils/state_manager.py
+++ b/src/utils/state_manager.py
@@ -16,7 +16,6 @@ from typing import Any
 
 from src.utils.logger import system_logger
 from src.utils.warning_symbols import (
-from src.core.decorators.errors import handles_errors
     error,
     invalid,
 )


### PR DESCRIPTION
Remove misplaced `from src.core.decorators.errors import handles_errors` statements to fix critical syntax errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d8ea330-c8eb-4a82-ba41-05121b70d422">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4d8ea330-c8eb-4a82-ba41-05121b70d422">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

