### PR TITLE
Fix training module syntax errors

### DIFF
--- a/src/training/calibration_manager.py
+++ b/src/training/calibration_manager.py
@@ -6,10 +6,10 @@ from datetime import datetime
 from typing import Any
 
 from .utils.logger import system_logger
-from src.utils.warning_symbols import (
 import logging
 import time
 
+from src.utils.warning_symbols import (
     error,
     failed,
     invalid,

--- a/src/training/di_training_manager.py
+++ b/src/training/di_training_manager.py
@@ -13,9 +13,9 @@ from .core.dependency_injection import DependencyContainer
 from .core.injectable_base import InjectableBase
 from .interfaces.base_interfaces import IExchangeClient, IStateManager
 
-from src.utils.warning_symbols import (
 import logging
 
+from src.utils.warning_symbols import (
     failed,
     initialization_error,
     invalid,

--- a/src/training/dual_model_system.py
+++ b/src/training/dual_model_system.py
@@ -22,7 +22,7 @@ from src.utils.decorators import (
 from .core.domain import quality_gate, secure_data_processing
 from .utils.confidence import aggregate_directional_confidences
 from .utils.logger import system_logger
-
+from src.utils.warning_symbols import (
     error,
     execution_error,
     initialization_error,

--- a/src/training/early_stage_optimization.py
+++ b/src/training/early_stage_optimization.py
@@ -20,8 +20,6 @@ except ImportError:
     OPTUNA_AVAILABLE = False
 try:
     from .steps.step06_labeling_components.regime_specific_triple_barrier_optimizer import RegimeSpecificTripleBarrierOptimizer, create_regime_specific_triple_barrier_optimizer
-import time
-
     REGIME_OPTIMIZER_AVAILABLE = True
 except ImportError:
     REGIME_OPTIMIZER_AVAILABLE = False

--- a/src/training/enhanced_lm_optimizer.py
+++ b/src/training/enhanced_lm_optimizer.py
@@ -38,10 +38,10 @@ from torch.utils.data import DataLoader, TensorDataset
 from .utils.logger import system_logger
 
 # Import Pydantic configuration
-try:
-    from src.training.enhanced_lm_config import (
 import logging
 
+try:
+    from src.training.enhanced_lm_config import (
         DEFAULT_CONFIG,
         EnhancedLMOptimizerConfig,
     )

--- a/src/training/ensemble_manager.py
+++ b/src/training/ensemble_manager.py
@@ -11,10 +11,10 @@ from src.utils.decorators import (
 from .utils.logger import system_logger
 
 # Removed trading_decorators imports - using core decorators instead
-from src.utils.warning_symbols import (
 import logging
 import time
 
+from src.utils.warning_symbols import (
     error,
     failed,
     invalid,

--- a/src/training/feature_engineering.py
+++ b/src/training/feature_engineering.py
@@ -1,9 +1,8 @@
 from collections.abc import Callable
-import src.utils.decorators
 import pandas as pd
 
-
-
+import src.utils.decorators
+from src.utils.decorators import (
     traced,
     validates,
 )

--- a/src/training/feature_integration.py
+++ b/src/training/feature_integration.py
@@ -36,8 +36,6 @@ class FeatureIntegrationManager:
             self.logger.info('🚀 Initializing feature integration manager...')
             if self.enable_advanced_features:
                 from .analyst.advanced_feature_engineering import AdvancedFeatureEngineering
-import logging
-
                 self.advanced_feature_engineering = AdvancedFeatureEngineering(self.config)
                 await self.advanced_feature_engineering.initialize()
             self.is_initialized = True

--- a/src/training/model_interpretability/interpretability_reporter.py
+++ b/src/training/model_interpretability/interpretability_reporter.py
@@ -42,11 +42,6 @@ class InterpretabilityReporter:
         try:
             # Use report manager for standardized report organization
             from .utils.report_manager import get_report_manager
-import json
-import logging
-import time
-import typing
-
             report_manager = get_report_manager()
             
             # Generate different report formats using report manager

--- a/src/training/model_interpretability/interpretability_visualizer.py
+++ b/src/training/model_interpretability/interpretability_visualizer.py
@@ -34,10 +34,6 @@ class InterpretabilityVisualizer:
         """Check if visualization libraries are available."""
         try:
             import matplotlib
-from typing import Any
-from typing import Dict
-from typing import Optional
-
             matplotlib.use('Agg')  # Use non-interactive backend
             self.plt = plt
             self.matplotlib = matplotlib

--- a/src/training/model_interpretability/lime_analyzer.py
+++ b/src/training/model_interpretability/lime_analyzer.py
@@ -33,11 +33,6 @@ class LIMEAnalyzer:
         """Check if LIME is available and initialize if possible."""
         try:
             import lime
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
-
             self.lime = lime
             self.lime_tabular = lime.lime_tabular
             self.lime_available = True

--- a/src/training/model_interpretability/model_explainer.py
+++ b/src/training/model_interpretability/model_explainer.py
@@ -39,9 +39,6 @@ class ModelExplainer:
             from .lime_analyzer import LIMEAnalyzer
             from .interpretability_visualizer import InterpretabilityVisualizer
             from .interpretability_reporter import InterpretabilityReporter
-from typing import Any
-from typing import Dict
-from typing import List
             
             self.shap_analyzer = SHAPAnalyzer(self.config)
             self.lime_analyzer = LIMEAnalyzer(self.config)

--- a/src/training/model_interpretability/shap_analyzer.py
+++ b/src/training/model_interpretability/shap_analyzer.py
@@ -33,11 +33,6 @@ class SHAPAnalyzer:
         """Check if SHAP is available and initialize if possible."""
         try:
             import shap
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
-
             self.shap = shap
             self.shap_available = True
             self.logger.info("✅ SHAP library available and initialized")

--- a/src/training/model_trainer.py
+++ b/src/training/model_trainer.py
@@ -44,11 +44,11 @@ from .utils.logger import system_logger
 
 # Import training pipeline decorators for comprehensive security and troubleshooting
 
-from src.utils.warning_symbols import (
 import logging
 import numpy as np
 import time
 
+from src.utils.warning_symbols import (
     error,
     failed,
     invalid,

--- a/src/training/multi_output_probability_trainer.py
+++ b/src/training/multi_output_probability_trainer.py
@@ -21,11 +21,11 @@ except ImportError:
     NEURAL_MODEL_CONFIGS = {}
     NeuralNetworkWrapper = None
     create_neural_model = None
-try:
-    from catboost import CatBoostClassifier
 import logging
 import time
 
+try:
+    from catboost import CatBoostClassifier
     CATBOOST_AVAILABLE = True
 except ImportError:
     CatBoostClassifier = None

--- a/src/training/training_manager.py
+++ b/src/training/training_manager.py
@@ -9,10 +9,10 @@ warnings.filterwarnings("ignore")
 # Import the new RegularizationManager
 from .core.decorators import handles_errors
 from .utils.logger import system_logger
-from src.utils.warning_symbols import (
 import logging
 import time
 
+from src.utils.warning_symbols import (
     error,
     failed,
     initialization_error,

--- a/src/training/training_orchestrator.py
+++ b/src/training/training_orchestrator.py
@@ -6,10 +6,10 @@ from datetime import datetime
 from typing import Any
 
 from src.utils.logger import system_logger
-from src.utils.warning_symbols import (
 import logging
 import time
 
+from src.utils.warning_symbols import (
     failed,
     invalid,
     missing,

--- a/src/training/validator.py
+++ b/src/training/validator.py
@@ -2,9 +2,9 @@
 import time
 from typing import Any
 
-from src.training.steps.data_preparation_components.training_validation_config import (
 import logging
 
+from src.training.steps.data_preparation_components.training_validation_config import (
     VALIDATION_FUNCTIONS,
     can_proceed_to_step,
     get_progression_rules,

--- a/src/training/wavelet_feature_selection_workflow.py
+++ b/src/training/wavelet_feature_selection_workflow.py
@@ -37,9 +37,9 @@ from src.training.steps.vectorized_advanced_feature_engineering import (
     VectorizedAdvancedFeatureEngineering,
 )
 from src.utils.logger import system_logger
-from src.utils.warning_symbols import (
 import logging
 
+from src.utils.warning_symbols import (
     error,
     failed,
     initialization_error,


### PR DESCRIPTION
Fix various Python syntax errors across training module files by correcting import placements, try/except blocks, and indentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-58f283b4-9c67-4457-a4a6-f19e91e4744d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-58f283b4-9c67-4457-a4a6-f19e91e4744d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

