### PR TITLE
Changes from background agent bc-6544abb3-a953-4fba-9017-8c51c5a5ffcb

### DIFF
--- a/src/feature_generation/categories/trend.py
+++ b/src/feature_generation/categories/trend.py
@@ -103,9 +103,14 @@ class TrendFeatureGenerator(VectorizedFeatureGenerator):
         dm_plus = np.maximum(high - np.roll(high, 1), 0)
         dm_minus = np.maximum(np.roll(low, 1) - low, 0)
 
+        # Convert to pandas Series for rolling operations
+        tr_series = pd.Series(tr)
+        dm_plus_series = pd.Series(dm_plus)
+        dm_minus_series = pd.Series(dm_minus)
+
         # Calculate Directional Indicators
-        di_plus = 100 * (dm_plus.rolling(period).mean() / tr.rolling(period).mean())
-        di_minus = 100 * (dm_minus.rolling(period).mean() / tr.rolling(period).mean())
+        di_plus = 100 * (dm_plus_series.rolling(period).mean() / tr_series.rolling(period).mean())
+        di_minus = 100 * (dm_minus_series.rolling(period).mean() / tr_series.rolling(period).mean())
 
         # Calculate ADX
         dx = 100 * np.abs(di_plus - di_minus) / (di_plus + di_minus)
@@ -214,9 +219,14 @@ class ADXGenerator(FeatureGenerator):
         dm_plus = np.maximum(high - np.roll(high, 1), 0)
         dm_minus = np.maximum(np.roll(low, 1) - low, 0)
 
+        # Convert to pandas Series for rolling operations
+        tr_series = pd.Series(tr)
+        dm_plus_series = pd.Series(dm_plus)
+        dm_minus_series = pd.Series(dm_minus)
+
         # Calculate Directional Indicators
-        di_plus = 100 * (dm_plus.rolling(period).mean() / tr.rolling(period).mean())
-        di_minus = 100 * (dm_minus.rolling(period).mean() / tr.rolling(period).mean())
+        di_plus = 100 * (dm_plus_series.rolling(period).mean() / tr_series.rolling(period).mean())
+        di_minus = 100 * (dm_minus_series.rolling(period).mean() / tr_series.rolling(period).mean())
 
         # Calculate ADX
         dx = 100 * np.abs(di_plus - di_minus) / (di_plus + di_minus)


### PR DESCRIPTION
Fix `AttributeError: 'numpy.ndarray' object has no attribute 'rolling'` in ADX and Trend feature generators by converting numpy arrays to pandas Series for rolling calculations.

This resolves the issue where feature generators were returning empty results due to incorrect method calls on numpy arrays, ensuring that features are now correctly generated.

---
<a href="https://cursor.com/background-agent?bcId=bc-6544abb3-a953-4fba-9017-8c51c5a5ffcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6544abb3-a953-4fba-9017-8c51c5a5ffcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

