### PR TITLE
Integrate analyst and tactician training artifacts

### DIFF
--- a/src/training/steps/model_training/sub_pipeline.py
+++ b/src/training/steps/model_training/sub_pipeline.py
@@ -39,39 +39,29 @@ from src.utils.tprint import tprint, tprint_info, tprint_success, tprint_error, 
 
 # Import orchestration and training steps
 try:
-    from ..models_training.analyst_pre_ml_orchestration import (
-        AnalystPreMLOrchestrator, AnalystPreMLConfig, AnalystPreMLResult
+    from ..models_training import (
+        AnalystPreMLConfig,
+        AnalystPreMLOrchestrator,
+        AnalystPreMLResult,
+        AnalystTrainingPipeline,
+        AnalystTrainingPipelineConfig,
+        AnalystTrainingPipelineResult,
+        TacticianPreMLConfig,
+        TacticianPreMLOrchestrator,
+        TacticianPreMLResult,
+        TacticianTrainingPipeline,
+        TacticianTrainingPipelineConfig,
+        TacticianTrainingPipelineResult,
     )
     ANALYST_PRE_ML_AVAILABLE = True
-except ImportError as e:
-    print(f"⚠️ Warning: analyst_pre_ml_orchestration not available: {e}")
-    ANALYST_PRE_ML_AVAILABLE = False
-
-try:
-    from ..models_training.analyst_training_pipeline import (
-        AnalystTrainingPipeline, AnalystTrainingPipelineConfig, AnalystTrainingPipelineResult
-    )
     ANALYST_TRAINING_AVAILABLE = True
-except ImportError as e:
-    print(f"⚠️ Warning: analyst_training_pipeline not available: {e}")
-    ANALYST_TRAINING_AVAILABLE = False
-
-try:
-    from ..models_training.tactician_pre_ml_orchestration import (
-        TacticianPreMLOrchestrator, TacticianPreMLConfig, TacticianPreMLResult
-    )
     TACTICIAN_PRE_ML_AVAILABLE = True
-except ImportError as e:
-    print(f"⚠️ Warning: tactician_pre_ml_orchestration not available: {e}")
-    TACTICIAN_PRE_ML_AVAILABLE = False
-
-try:
-    from ..models_training.tactician_training_pipeline import (
-        TacticianTrainingPipeline, TacticianTrainingPipelineConfig, TacticianTrainingPipelineResult
-    )
     TACTICIAN_TRAINING_AVAILABLE = True
 except ImportError as e:
-    print(f"⚠️ Warning: tactician_training_pipeline not available: {e}")
+    print(f"⚠️ Warning: model training orchestrators not available: {e}")
+    ANALYST_PRE_ML_AVAILABLE = False
+    ANALYST_TRAINING_AVAILABLE = False
+    TACTICIAN_PRE_ML_AVAILABLE = False
     TACTICIAN_TRAINING_AVAILABLE = False
 
 logger = system_logger.getChild('ModelTrainingSubPipeline')
@@ -605,6 +595,7 @@ class ModelTrainingSubPipeline:
                 'regime_features': regime_features,
                 'metadata': metadata
             }
+            result.metadata = metadata
             result.output_files = saved_files
 
             self._current_pipeline_state['analyst_training_frame'] = final_features
@@ -705,6 +696,12 @@ class ModelTrainingSubPipeline:
                 'feature_columns': feature_columns,
                 'target_columns': target_columns
             }
+            result.metadata = {
+                'feature_columns': feature_columns,
+                'target_columns': target_columns,
+                'training_frame_rows': len(training_frame),
+                'training_frame_columns': training_frame.shape[1]
+            }
             result.output_files = saved_files
 
             self._current_pipeline_state['analyst_training_frame'] = training_frame
@@ -781,6 +778,12 @@ class ModelTrainingSubPipeline:
                 'ensemble_metrics': ensemble_metrics,
                 'metadata': ensemble_metadata,
                 'predictions': predictions_df
+            }
+            result.metadata = {
+                'feature_columns': feature_columns,
+                'training_frame_rows': len(training_frame),
+                'training_frame_columns': training_frame.shape[1],
+                'ensemble_metrics': ensemble_metrics
             }
             result.output_files = saved_files
 
@@ -890,6 +893,7 @@ class ModelTrainingSubPipeline:
                 'regime_features': regime_features,
                 'metadata': metadata
             }
+            result.metadata = metadata
             result.output_files = saved_files
 
             self._current_pipeline_state['tactician_training_frame'] = final_features
@@ -991,6 +995,12 @@ class ModelTrainingSubPipeline:
                 'feature_columns': feature_columns,
                 'target_columns': target_columns
             }
+            result.metadata = {
+                'feature_columns': feature_columns,
+                'target_columns': target_columns,
+                'training_frame_rows': len(training_frame),
+                'training_frame_columns': training_frame.shape[1]
+            }
             result.output_files = saved_files
 
             self._current_pipeline_state['tactician_training_frame'] = training_frame
@@ -1069,6 +1079,12 @@ class ModelTrainingSubPipeline:
                 'ensemble_metrics': ensemble_metrics,
                 'metadata': ensemble_metadata,
                 'predictions': predictions_df
+            }
+            result.metadata = {
+                'feature_columns': feature_columns,
+                'training_frame_rows': len(training_frame),
+                'training_frame_columns': training_frame.shape[1],
+                'ensemble_metrics': ensemble_metrics
             }
             result.output_files = saved_files
 

--- a/src/training/steps/model_training/sub_pipeline.py
+++ b/src/training/steps/model_training/sub_pipeline.py
@@ -17,19 +17,29 @@ TACTICIAN PIPELINE (5m timeframe - WHEN we trade):
 Each model type (short/long) is trained separately.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Iterable
 from datetime import datetime
 from enum import Enum
 from dataclasses import dataclass, field
+from pathlib import Path
+import json
+
 import pandas as pd
 import numpy as np
+
+try:
+    import joblib
+    JOBLIB_AVAILABLE = True
+except ImportError:  # pragma: no cover - optional dependency
+    JOBLIB_AVAILABLE = False
+    joblib = None
 
 from src.utils.logger import system_logger
 from src.utils.tprint import tprint, tprint_info, tprint_success, tprint_error, tprint_warning
 
 # Import orchestration and training steps
 try:
-    from .analyst_pre_ml_orchestration import (
+    from ..models_training.analyst_pre_ml_orchestration import (
         AnalystPreMLOrchestrator, AnalystPreMLConfig, AnalystPreMLResult
     )
     ANALYST_PRE_ML_AVAILABLE = True
@@ -38,7 +48,7 @@ except ImportError as e:
     ANALYST_PRE_ML_AVAILABLE = False
 
 try:
-    from .analyst_training_pipeline import (
+    from ..models_training.analyst_training_pipeline import (
         AnalystTrainingPipeline, AnalystTrainingPipelineConfig, AnalystTrainingPipelineResult
     )
     ANALYST_TRAINING_AVAILABLE = True
@@ -47,7 +57,7 @@ except ImportError as e:
     ANALYST_TRAINING_AVAILABLE = False
 
 try:
-    from .tactician_pre_ml_orchestration import (
+    from ..models_training.tactician_pre_ml_orchestration import (
         TacticianPreMLOrchestrator, TacticianPreMLConfig, TacticianPreMLResult
     )
     TACTICIAN_PRE_ML_AVAILABLE = True
@@ -56,7 +66,7 @@ except ImportError as e:
     TACTICIAN_PRE_ML_AVAILABLE = False
 
 try:
-    from .tactician_training_pipeline import (
+    from ..models_training.tactician_training_pipeline import (
         TacticianTrainingPipeline, TacticianTrainingPipelineConfig, TacticianTrainingPipelineResult
     )
     TACTICIAN_TRAINING_AVAILABLE = True
@@ -165,6 +175,227 @@ class ModelTrainingSubPipeline:
             self.tactician_training = TacticianTrainingPipeline()
         else:
             self.tactician_training = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _json_default(self, obj: Any) -> Any:
+        """Fallback serializer for JSON dumps."""
+        if isinstance(obj, (pd.Series, pd.Index)):
+            return obj.tolist()
+        if isinstance(obj, pd.DataFrame):
+            return obj.to_dict(orient='list')
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if isinstance(obj, (datetime,)):
+            return obj.isoformat()
+        return str(obj)
+
+    def _ensure_directory(self, path: Path) -> None:
+        """Ensure that a directory exists."""
+        path.mkdir(parents=True, exist_ok=True)
+
+    def _read_parquet(self, path: Path) -> pd.DataFrame:
+        """Read a parquet file into a DataFrame."""
+        self.logger.debug(f"Loading parquet file: {path}")
+        return pd.read_parquet(path)
+
+    def _find_latest_file(
+        self,
+        directories: Iterable[Path],
+        include_tokens: Optional[List[str]] = None,
+        suffixes: Optional[List[str]] = None
+    ) -> Optional[Path]:
+        """Find the most recent file matching the include tokens and suffixes."""
+
+        include_tokens = include_tokens or []
+        suffixes = suffixes or ['.parquet']
+
+        candidates: List[Path] = []
+        for directory in directories:
+            if not directory or not directory.exists():
+                continue
+
+            for suffix in suffixes:
+                candidates.extend([
+                    path for path in directory.glob(f"*{suffix}")
+                    if all(token.lower() in path.name.lower() for token in include_tokens)
+                ])
+
+        if not candidates:
+            return None
+
+        return max(candidates, key=lambda p: p.stat().st_mtime)
+
+    def _load_input_dataframe(
+        self,
+        config: SubPipelineConfig,
+        *,
+        role: str,
+        timeframe: str,
+        kind: str,
+        required: bool = False,
+        custom_key: Optional[str] = None,
+        default_directories: Optional[List[Path]] = None
+    ) -> Optional[pd.DataFrame]:
+        """Load an input DataFrame from pipeline state, custom path, or default locations."""
+
+        state_key = f"{role}_{kind}"
+        if state_key in self._current_pipeline_state:
+            state_value = self._current_pipeline_state[state_key]
+            if isinstance(state_value, pd.DataFrame):
+                return state_value.copy()
+
+        # Custom configuration override
+        custom_keys = [
+            custom_key or f"{role}_{kind}_path",
+            f"{role}_{timeframe}_{kind}_path",
+            f"{kind}_path"
+        ]
+        for key in custom_keys:
+            if not key:
+                continue
+            path_value = config.custom_params.get(key)
+            if path_value:
+                path = Path(path_value)
+                if path.exists():
+                    return self._read_parquet(path)
+                else:
+                    self.logger.warning(f"Configured path does not exist for {role} {kind}: {path}")
+
+        # Search default directories
+        default_directories = default_directories or []
+        search_directories = [
+            Path(config.output_directory) / role / 'pre_ml',
+            Path('generated/market_analysis'),
+            Path('generated/market_analysis/regime_data_splitting'),
+            Path('generated/market_analysis/pid_features')
+        ] + default_directories
+
+        include_tokens = [role, timeframe, kind]
+        candidate = self._find_latest_file(search_directories, include_tokens=include_tokens)
+        if candidate:
+            return self._read_parquet(candidate)
+
+        if required:
+            raise FileNotFoundError(
+                f"Unable to locate required {role} {kind} data for timeframe {timeframe}. "
+                f"Provide a path via config.custom_params or ensure generated artifacts exist."
+            )
+
+        return None
+
+    def _save_dataframe_artifact(self, df: pd.DataFrame, path: Path) -> str:
+        """Persist a DataFrame to parquet and return the saved path."""
+        self._ensure_directory(path.parent)
+        df.to_parquet(path)
+        return str(path)
+
+    def _save_json_artifact(self, payload: Dict[str, Any], path: Path) -> str:
+        """Persist a JSON payload and return the saved path."""
+        self._ensure_directory(path.parent)
+        with path.open('w') as handle:
+            json.dump(payload, handle, indent=2, default=self._json_default)
+        return str(path)
+
+    def _get_target_columns(self, data: pd.DataFrame) -> List[str]:
+        """Infer target columns from a training DataFrame."""
+        candidate_targets = [col for col in data.columns if col.startswith('target_')]
+        if not candidate_targets:
+            raise ValueError("No target columns found in training data (expected columns starting with 'target_')")
+        return candidate_targets
+
+    def _merge_regime_features(
+        self,
+        base_frame: pd.DataFrame,
+        regime_features: Optional[pd.DataFrame]
+    ) -> pd.DataFrame:
+        """Merge regime features into the base feature frame if available."""
+        if regime_features is None or regime_features.empty:
+            return base_frame
+
+        aligned = base_frame.join(regime_features, how='left')
+        self.logger.info(
+            f"Merged regime features: base columns={base_frame.shape[1]}, "
+            f"regime columns={regime_features.shape[1]}, result columns={aligned.shape[1]}"
+        )
+        return aligned
+
+    def _collect_regime_features(self, artifacts: Dict[str, Any]) -> Optional[pd.DataFrame]:
+        """Extract regime feature DataFrame from orchestration artifacts if present."""
+        regime_features = artifacts.get('regime_features') or artifacts.get('metadata', {}).get('regime_features')
+        if isinstance(regime_features, pd.DataFrame):
+            return regime_features
+        if isinstance(regime_features, dict):
+            try:
+                return pd.DataFrame(regime_features)
+            except Exception:  # pragma: no cover - defensive
+                return None
+        if isinstance(regime_features, np.ndarray):
+            return pd.DataFrame(regime_features)
+        return None
+
+    def _generate_model_predictions(
+        self,
+        models: Dict[str, Any],
+        features: pd.DataFrame
+    ) -> pd.DataFrame:
+        """Generate predictions for each model given a feature matrix."""
+        predictions: Dict[str, np.ndarray] = {}
+        for model_name, model in (models or {}).items():
+            if not hasattr(model, 'predict'):
+                continue
+            try:
+                model_predictions = model.predict(features.values)
+                if isinstance(model_predictions, (list, tuple)):
+                    model_predictions = np.asarray(model_predictions)
+                if model_predictions.ndim == 1:
+                    predictions[model_name] = model_predictions
+                else:
+                    for idx in range(model_predictions.shape[1]):
+                        predictions[f"{model_name}_{idx}"] = model_predictions[:, idx]
+            except Exception as exc:  # pragma: no cover - model specific edge cases
+                self.logger.warning(f"Failed to generate predictions for model {model_name}: {exc}")
+
+        if not predictions:
+            return pd.DataFrame(index=features.index)
+
+        return pd.DataFrame(predictions, index=features.index)
+
+    def _persist_models(self, models: Dict[str, Any], destination: Path, name_filter: Optional[List[str]] = None) -> List[str]:
+        """Persist selected models to disk using joblib."""
+        saved_paths: List[str] = []
+        if not models:
+            return saved_paths
+
+        if not JOBLIB_AVAILABLE:
+            self.logger.warning("joblib not available - skipping model persistence")
+            return saved_paths
+
+        self._ensure_directory(destination)
+        for model_name, model in models.items():
+            if name_filter and not any(token in model_name.lower() for token in name_filter):
+                continue
+            try:
+                model_path = destination / f"{model_name}.joblib"
+                joblib.dump(model, model_path)
+                saved_paths.append(str(model_path))
+            except Exception as exc:  # pragma: no cover - serialization edge cases
+                self.logger.warning(f"Failed to persist model {model_name}: {exc}")
+        return saved_paths
+
+    def _filter_predictions_by_threshold(
+        self,
+        predictions: Optional[pd.DataFrame],
+        threshold: float
+    ) -> Optional[pd.DataFrame]:
+        """Filter predictions based on absolute value threshold across any column."""
+        if predictions is None or predictions.empty:
+            return predictions
+
+        mask = (predictions.abs() >= threshold).any(axis=1)
+        return predictions.loc[mask]
     
     async def execute_pipeline(self, config: SubPipelineConfig) -> Dict[str, Any]:
         """
@@ -309,24 +540,77 @@ class ModelTrainingSubPipeline:
         try:
             if not self.analyst_pre_ml:
                 raise RuntimeError("Analyst pre-ML orchestrator not available")
-            
+
             self.logger.info('🔧 Executing Analyst Pre-ML Orchestration (15m)...')
-            
-            # Execute orchestration
-            orchestration_result = await self.analyst_pre_ml.orchestrate(
-                training_data=None,  # TODO: Load from artifacts
-                regime_assignments=None,  # TODO: Load from market_analysis
+
+            training_data = self._load_input_dataframe(
+                config,
+                role='analyst',
+                timeframe=config.analyst_timeframe,
+                kind='training_data',
+                required=True
             )
-            
+
+            regime_assignments = self._load_input_dataframe(
+                config,
+                role='analyst',
+                timeframe=config.analyst_timeframe,
+                kind='regime_assignments',
+                required=False
+            )
+
+            orchestration_result = await self.analyst_pre_ml.orchestrate(
+                training_data=training_data,
+                regime_assignments=regime_assignments,
+            )
+
             result.success = orchestration_result.success
             result.status = SubPipelineStatus.COMPLETED if orchestration_result.success else SubPipelineStatus.FAILED
             result.error_message = orchestration_result.error_message
-            result.artifacts = {
-                'final_features': orchestration_result.final_features,
-                'selected_features': orchestration_result.selected_feature_names,
-                'feature_count': orchestration_result.final_feature_count
+
+            if not orchestration_result.success:
+                return result
+
+            final_features = orchestration_result.final_features
+            if final_features is None:
+                raise ValueError('Analyst pre-ML orchestration did not return final features')
+
+            regime_features = self._collect_regime_features(orchestration_result.feature_selection_result or {})
+            metadata = {
+                'selected_features': orchestration_result.selected_feature_names or [],
+                'feature_count': orchestration_result.final_feature_count,
+                'total_samples': orchestration_result.total_samples,
+                'regime_features': regime_features,
+                'regime_assignments_provided': regime_assignments is not None
             }
-            
+
+            output_dir = Path(config.output_directory) / 'analyst' / 'pre_ml'
+            saved_files: List[str] = []
+            saved_files.append(self._save_dataframe_artifact(final_features, output_dir / 'final_features.parquet'))
+            if regime_features is not None and not regime_features.empty:
+                saved_files.append(self._save_dataframe_artifact(regime_features, output_dir / 'regime_features.parquet'))
+                metadata['regime_feature_columns'] = list(regime_features.columns)
+
+            saved_files.append(self._save_json_artifact({
+                'selected_features': metadata['selected_features'],
+                'feature_count': metadata['feature_count'],
+                'total_samples': metadata['total_samples'],
+                'regime_feature_columns': metadata.get('regime_feature_columns', [])
+            }, output_dir / 'metadata.json'))
+
+            result.artifacts = {
+                'final_features': final_features,
+                'selected_features': metadata['selected_features'],
+                'feature_count': metadata['feature_count'],
+                'regime_features': regime_features,
+                'metadata': metadata
+            }
+            result.output_files = saved_files
+
+            self._current_pipeline_state['analyst_training_frame'] = final_features
+            self._current_pipeline_state['analyst_regime_features'] = regime_features
+            self._current_pipeline_state['analyst_pre_ml_metadata'] = metadata
+
         except Exception as e:
             result.status = SubPipelineStatus.FAILED
             result.error_message = str(e)
@@ -349,23 +633,86 @@ class ModelTrainingSubPipeline:
         try:
             if not self.analyst_training:
                 raise RuntimeError("Analyst training pipeline not available")
-            
+
             self.logger.info('📈 Executing Analyst Models Training...')
-            
-            # Execute training
+
+            final_features = pre_ml_result.artifacts.get('final_features')
+            if final_features is None or final_features.empty:
+                raise ValueError('Analyst pre-ML artifacts missing final features')
+
+            selected_features = list(pre_ml_result.artifacts.get('selected_features', []))
+            if not selected_features:
+                raise ValueError('Analyst pre-ML artifacts missing selected features')
+
+            regime_features = self._collect_regime_features(pre_ml_result.artifacts)
+            if regime_features is None:
+                regime_features = self._current_pipeline_state.get('analyst_regime_features')
+
+            training_frame = self._merge_regime_features(final_features, regime_features)
+            feature_columns = list(dict.fromkeys(selected_features + ([
+                col for col in (regime_features.columns if isinstance(regime_features, pd.DataFrame) else [])
+                if col not in selected_features
+            ])))
+
+            target_columns = self._get_target_columns(training_frame)
+
+            output_dir = Path(config.output_directory) / 'analyst' / 'models'
+            saved_files: List[str] = []
+            saved_files.append(self._save_dataframe_artifact(training_frame, output_dir / 'training_frame.parquet'))
+
             training_result = await self.analyst_training.train_analyst_models(
-                training_data=pre_ml_result.artifacts.get('final_features'),
-                feature_columns=pre_ml_result.artifacts.get('selected_features', []),
-                target_columns=['target_long', 'target_short'],  # TODO: Get from config
+                training_data=training_frame,
+                feature_columns=feature_columns,
+                target_columns=target_columns,
             )
-            
+
             result.success = training_result.base_training_completed
             result.status = SubPipelineStatus.COMPLETED if result.success else SubPipelineStatus.FAILED
-            result.artifacts = {
-                'base_models': training_result.base_models,
-                'metrics': training_result.base_training_metrics
+
+            base_models = training_result.base_models or {}
+            base_metrics = training_result.base_training_metrics or {}
+            ensemble_models = training_result.ensemble_models or {}
+            ensemble_metrics = training_result.ensemble_metrics or {}
+
+            predictions_df = self._generate_model_predictions(
+                ensemble_models or base_models,
+                training_frame[feature_columns]
+            )
+
+            metrics_payload = {
+                'base': base_metrics,
+                'ensemble': ensemble_metrics,
+                'feature_columns': feature_columns,
+                'target_columns': target_columns
             }
-            
+            saved_files.append(self._save_json_artifact(metrics_payload, output_dir / 'metrics.json'))
+
+            if not predictions_df.empty:
+                saved_files.append(self._save_dataframe_artifact(predictions_df, output_dir / 'ensemble_predictions.parquet'))
+
+            model_paths = self._persist_models(
+                base_models,
+                destination=output_dir / 'nas_tas_models',
+                name_filter=['nas', 'tas']
+            )
+            saved_files.extend(model_paths)
+
+            result.artifacts = {
+                'base_models': base_models,
+                'ensemble_models': ensemble_models,
+                'metrics': metrics_payload,
+                'predictions': predictions_df,
+                'feature_columns': feature_columns,
+                'target_columns': target_columns
+            }
+            result.output_files = saved_files
+
+            self._current_pipeline_state['analyst_training_frame'] = training_frame
+            self._current_pipeline_state['analyst_feature_columns'] = feature_columns
+            self._current_pipeline_state['analyst_models'] = base_models
+            self._current_pipeline_state['analyst_ensemble_models'] = ensemble_models
+            self._current_pipeline_state['analyst_ensemble_predictions'] = predictions_df
+
         except Exception as e:
             result.status = SubPipelineStatus.FAILED
             result.error_message = str(e)
@@ -386,20 +733,61 @@ class ModelTrainingSubPipeline:
         )
         
         try:
-            if not self.analyst_training:
-                raise RuntimeError("Analyst training pipeline not available")
-            
+            if not self.analyst_training or not getattr(self.analyst_training, 'ensemble_trainer', None):
+                raise RuntimeError("Analyst ensemble trainer not available")
+
             self.logger.info('🔄 Executing Analyst Ensemble Training...')
-            
-            # Ensemble training is handled within the analyst_training pipeline
-            # The result is already available from the models training step
+
+            training_frame: Optional[pd.DataFrame] = self._current_pipeline_state.get('analyst_training_frame')
+            feature_columns: List[str] = models_result.artifacts.get('feature_columns') or self._current_pipeline_state.get('analyst_feature_columns', [])
+            base_models = models_result.artifacts.get('base_models') or self._current_pipeline_state.get('analyst_models')
+
+            if training_frame is None or training_frame.empty:
+                raise ValueError('Analyst training frame unavailable for ensemble step')
+            if not feature_columns:
+                raise ValueError('Analyst feature columns unavailable for ensemble step')
+            if not base_models:
+                raise ValueError('Analyst base models unavailable for ensemble step')
+
+            target_columns: List[str] = models_result.artifacts.get('target_columns') or self._get_target_columns(training_frame)
+
+            ensemble_trainer = self.analyst_training.ensemble_trainer
+            ensemble_output = await ensemble_trainer.train_analyst_ensemble(
+                training_data=training_frame,
+                base_models=base_models,
+                feature_columns=feature_columns,
+                target_columns=target_columns,
+            )
+
+            ensemble_models = ensemble_output.get('models', {})
+            ensemble_metrics = ensemble_output.get('metrics', {})
+            ensemble_metadata = ensemble_output.get('metadata', {})
+
+            predictions_df = self._generate_model_predictions(ensemble_models, training_frame[feature_columns])
+
+            output_dir = Path(config.output_directory) / 'analyst' / 'ensemble'
+            saved_files: List[str] = []
+            if not predictions_df.empty:
+                saved_files.append(self._save_dataframe_artifact(predictions_df, output_dir / 'ensemble_predictions.parquet'))
+            saved_files.append(self._save_json_artifact({
+                'metrics': ensemble_metrics,
+                'metadata': ensemble_metadata
+            }, output_dir / 'ensemble_metrics.json'))
+
             result.success = True
             result.status = SubPipelineStatus.COMPLETED
             result.artifacts = {
-                'ensemble_models': models_result.artifacts.get('base_models'),  # Placeholder
-                'predictions': None  # TODO: Generate predictions
+                'ensemble_models': ensemble_models,
+                'ensemble_metrics': ensemble_metrics,
+                'metadata': ensemble_metadata,
+                'predictions': predictions_df
             }
-            
+            result.output_files = saved_files
+
+            self._current_pipeline_state['analyst_ensemble_models'] = ensemble_models
+            if not predictions_df.empty:
+                self._current_pipeline_state['analyst_ensemble_predictions'] = predictions_df
+
         except Exception as e:
             result.status = SubPipelineStatus.FAILED
             result.error_message = str(e)
@@ -422,26 +810,92 @@ class ModelTrainingSubPipeline:
         try:
             if not self.tactician_pre_ml:
                 raise RuntimeError("Tactician pre-ML orchestrator not available")
-            
+
             self.logger.info('🔧 Executing Tactician Pre-ML Orchestration (5m, filtered)...')
-            
-            # Execute orchestration with Analyst filtering
-            orchestration_result = await self.tactician_pre_ml.orchestrate(
-                training_data=None,  # TODO: Load from artifacts
-                analyst_predictions=analyst_predictions,
-                regime_assignments=None,  # TODO: Load from market_analysis
+
+            training_data = self._load_input_dataframe(
+                config,
+                role='tactician',
+                timeframe=config.tactician_timeframe,
+                kind='training_data',
+                required=True
             )
-            
+
+            analyst_predictions_df = analyst_predictions
+            if analyst_predictions_df is None:
+                analyst_predictions_df = self._current_pipeline_state.get('analyst_ensemble_predictions')
+
+            if isinstance(analyst_predictions_df, pd.DataFrame):
+                analyst_predictions_df = self._filter_predictions_by_threshold(
+                    analyst_predictions_df,
+                    config.analyst_confidence_threshold
+                )
+
+            regime_assignments = self._load_input_dataframe(
+                config,
+                role='tactician',
+                timeframe=config.tactician_timeframe,
+                kind='regime_assignments',
+                required=False
+            )
+
+            orchestration_result = await self.tactician_pre_ml.orchestrate(
+                training_data=training_data,
+                analyst_predictions=analyst_predictions_df,
+                regime_assignments=regime_assignments,
+            )
+
             result.success = orchestration_result.success
             result.status = SubPipelineStatus.COMPLETED if orchestration_result.success else SubPipelineStatus.FAILED
             result.error_message = orchestration_result.error_message
-            result.artifacts = {
-                'final_features': orchestration_result.final_features,
-                'selected_features': orchestration_result.selected_feature_names,
+
+            if not orchestration_result.success:
+                return result
+
+            final_features = orchestration_result.final_features
+            if final_features is None:
+                raise ValueError('Tactician pre-ML orchestration did not return final features')
+
+            regime_features = self._collect_regime_features(orchestration_result.feature_selection_result or {})
+            metadata = {
+                'selected_features': orchestration_result.selected_feature_names or [],
                 'feature_count': orchestration_result.final_feature_count,
-                'filter_ratio': orchestration_result.filter_ratio
+                'filter_ratio': orchestration_result.filter_ratio,
+                'total_samples_before_filter': orchestration_result.total_samples_before_filter,
+                'total_samples_after_filter': orchestration_result.total_samples_after_filter,
+                'regime_features': regime_features
             }
-            
+
+            output_dir = Path(config.output_directory) / 'tactician' / 'pre_ml'
+            saved_files: List[str] = []
+            saved_files.append(self._save_dataframe_artifact(final_features, output_dir / 'final_features.parquet'))
+            if regime_features is not None and not regime_features.empty:
+                saved_files.append(self._save_dataframe_artifact(regime_features, output_dir / 'regime_features.parquet'))
+                metadata['regime_feature_columns'] = list(regime_features.columns)
+
+            saved_files.append(self._save_json_artifact({
+                'selected_features': metadata['selected_features'],
+                'feature_count': metadata['feature_count'],
+                'filter_ratio': metadata['filter_ratio'],
+                'total_samples_before_filter': metadata['total_samples_before_filter'],
+                'total_samples_after_filter': metadata['total_samples_after_filter'],
+                'regime_feature_columns': metadata.get('regime_feature_columns', [])
+            }, output_dir / 'metadata.json'))
+
+            result.artifacts = {
+                'final_features': final_features,
+                'selected_features': metadata['selected_features'],
+                'feature_count': metadata['feature_count'],
+                'filter_ratio': metadata['filter_ratio'],
+                'regime_features': regime_features,
+                'metadata': metadata
+            }
+            result.output_files = saved_files
+
+            self._current_pipeline_state['tactician_training_frame'] = final_features
+            self._current_pipeline_state['tactician_regime_features'] = regime_features
+            self._current_pipeline_state['tactician_pre_ml_metadata'] = metadata
+
         except Exception as e:
             result.status = SubPipelineStatus.FAILED
             result.error_message = str(e)
@@ -464,23 +918,86 @@ class ModelTrainingSubPipeline:
         try:
             if not self.tactician_training:
                 raise RuntimeError("Tactician training pipeline not available")
-            
+
             self.logger.info('📈 Executing Tactician Models Training...')
-            
-            # Execute training
+
+            final_features = pre_ml_result.artifacts.get('final_features')
+            if final_features is None or final_features.empty:
+                raise ValueError('Tactician pre-ML artifacts missing final features')
+
+            selected_features = list(pre_ml_result.artifacts.get('selected_features', []))
+            if not selected_features:
+                raise ValueError('Tactician pre-ML artifacts missing selected features')
+
+            regime_features = self._collect_regime_features(pre_ml_result.artifacts)
+            if regime_features is None:
+                regime_features = self._current_pipeline_state.get('tactician_regime_features')
+
+            analyst_predictions_df: Optional[pd.DataFrame] = self._current_pipeline_state.get('analyst_ensemble_predictions')
+            if isinstance(analyst_predictions_df, pd.DataFrame) and not analyst_predictions_df.empty:
+                analyst_predictions_df = analyst_predictions_df.reindex(final_features.index).add_prefix('analyst_')
+
+            training_frame = self._merge_regime_features(final_features, regime_features)
+            if isinstance(analyst_predictions_df, pd.DataFrame):
+                training_frame = training_frame.join(analyst_predictions_df, how='left')
+
+            additional_features: List[str] = []
+            if isinstance(regime_features, pd.DataFrame):
+                additional_features.extend([
+                    col for col in regime_features.columns if col not in selected_features
+                ])
+            if isinstance(analyst_predictions_df, pd.DataFrame):
+                additional_features.extend(list(analyst_predictions_df.columns))
+
+            feature_columns = list(dict.fromkeys(selected_features + additional_features))
+            target_columns = self._get_target_columns(training_frame)
+
+            output_dir = Path(config.output_directory) / 'tactician' / 'models'
+            saved_files: List[str] = []
+            saved_files.append(self._save_dataframe_artifact(training_frame, output_dir / 'training_frame.parquet'))
+
             training_result = await self.tactician_training.train_tactician_models(
-                training_data=pre_ml_result.artifacts.get('final_features'),
-                feature_columns=pre_ml_result.artifacts.get('selected_features', []),
-                target_columns=['target_long', 'target_short'],  # TODO: Get from config
+                training_data=training_frame,
+                feature_columns=feature_columns,
+                target_columns=target_columns,
             )
-            
+
             result.success = training_result.base_training_completed
             result.status = SubPipelineStatus.COMPLETED if result.success else SubPipelineStatus.FAILED
-            result.artifacts = {
-                'base_models': training_result.base_models,
-                'metrics': training_result.base_training_metrics
+
+            base_models = training_result.base_models or {}
+            base_metrics = training_result.base_training_metrics or {}
+            ensemble_models = training_result.ensemble_models or {}
+            ensemble_metrics = training_result.ensemble_metrics or {}
+
+            predictions_df = self._generate_model_predictions(base_models, training_frame[feature_columns])
+
+            metrics_payload = {
+                'base': base_metrics,
+                'ensemble': ensemble_metrics,
+                'feature_columns': feature_columns,
+                'target_columns': target_columns
             }
-            
+            saved_files.append(self._save_json_artifact(metrics_payload, output_dir / 'metrics.json'))
+
+            if not predictions_df.empty:
+                saved_files.append(self._save_dataframe_artifact(predictions_df, output_dir / 'base_model_predictions.parquet'))
+
+            result.artifacts = {
+                'base_models': base_models,
+                'ensemble_models': ensemble_models,
+                'metrics': metrics_payload,
+                'base_predictions': predictions_df,
+                'feature_columns': feature_columns,
+                'target_columns': target_columns
+            }
+            result.output_files = saved_files
+
+            self._current_pipeline_state['tactician_training_frame'] = training_frame
+            self._current_pipeline_state['tactician_feature_columns'] = feature_columns
+            self._current_pipeline_state['tactician_models'] = base_models
+            self._current_pipeline_state['tactician_base_predictions'] = predictions_df
+
         except Exception as e:
             result.status = SubPipelineStatus.FAILED
             result.error_message = str(e)
@@ -501,20 +1018,64 @@ class ModelTrainingSubPipeline:
         )
         
         try:
-            if not self.tactician_training:
-                raise RuntimeError("Tactician training pipeline not available")
-            
+            if not self.tactician_training or not getattr(self.tactician_training, 'ensemble_trainer', None):
+                raise RuntimeError("Tactician ensemble trainer not available")
+
             self.logger.info('🔄 Executing Tactician Ensemble Training...')
-            
-            # Ensemble training is handled within the tactician_training pipeline
-            # The result is already available from the models training step
+
+            training_frame: Optional[pd.DataFrame] = self._current_pipeline_state.get('tactician_training_frame')
+            feature_columns: List[str] = models_result.artifacts.get('feature_columns') or self._current_pipeline_state.get('tactician_feature_columns', [])
+            base_models = models_result.artifacts.get('base_models') or self._current_pipeline_state.get('tactician_models')
+            base_predictions = models_result.artifacts.get('base_predictions') or self._current_pipeline_state.get('tactician_base_predictions')
+
+            if training_frame is None or training_frame.empty:
+                raise ValueError('Tactician training frame unavailable for ensemble step')
+            if not feature_columns:
+                raise ValueError('Tactician feature columns unavailable for ensemble step')
+            if not base_models:
+                raise ValueError('Tactician base models unavailable for ensemble step')
+
+            target_columns: List[str] = models_result.artifacts.get('target_columns') or self._get_target_columns(training_frame)
+
+            ensemble_trainer = self.tactician_training.ensemble_trainer
+            ensemble_output = await ensemble_trainer.train_tactician_ensemble(
+                training_data=training_frame,
+                base_models=base_models,
+                feature_columns=feature_columns,
+                target_columns=target_columns,
+                base_model_predictions=base_predictions,
+                analyst_predictions=self._current_pipeline_state.get('analyst_ensemble_predictions')
+            )
+
+            ensemble_models = ensemble_output.get('models', {})
+            ensemble_metrics = ensemble_output.get('metrics', {})
+            ensemble_metadata = ensemble_output.get('metadata', {})
+
+            predictions_df = self._generate_model_predictions(ensemble_models, training_frame[feature_columns])
+
+            output_dir = Path(config.output_directory) / 'tactician' / 'ensemble'
+            saved_files: List[str] = []
+            if not predictions_df.empty:
+                saved_files.append(self._save_dataframe_artifact(predictions_df, output_dir / 'ensemble_predictions.parquet'))
+            saved_files.append(self._save_json_artifact({
+                'metrics': ensemble_metrics,
+                'metadata': ensemble_metadata
+            }, output_dir / 'ensemble_metrics.json'))
+
             result.success = True
             result.status = SubPipelineStatus.COMPLETED
             result.artifacts = {
-                'ensemble_models': models_result.artifacts.get('base_models'),  # Placeholder
-                'predictions': None  # TODO: Generate predictions
+                'ensemble_models': ensemble_models,
+                'ensemble_metrics': ensemble_metrics,
+                'metadata': ensemble_metadata,
+                'predictions': predictions_df
             }
-            
+            result.output_files = saved_files
+
+            self._current_pipeline_state['tactician_ensemble_models'] = ensemble_models
+            if not predictions_df.empty:
+                self._current_pipeline_state['tactician_ensemble_predictions'] = predictions_df
+
         except Exception as e:
             result.status = SubPipelineStatus.FAILED
             result.error_message = str(e)

--- a/src/training/steps/models_training/__init__.py
+++ b/src/training/steps/models_training/__init__.py
@@ -1,0 +1,41 @@
+"""Utilities for orchestrating model training workflows.
+
+This package groups the reusable analyst and tactician training orchestrators
+that power the higher-level model training sub-pipeline.
+"""
+
+from .analyst_pre_ml_orchestration import (  # noqa: F401
+    AnalystPreMLConfig,
+    AnalystPreMLOrchestrator,
+    AnalystPreMLResult,
+)
+from .analyst_training_pipeline import (  # noqa: F401
+    AnalystTrainingPipeline,
+    AnalystTrainingPipelineConfig,
+    AnalystTrainingPipelineResult,
+)
+from .tactician_pre_ml_orchestration import (  # noqa: F401
+    TacticianPreMLConfig,
+    TacticianPreMLOrchestrator,
+    TacticianPreMLResult,
+)
+from .tactician_training_pipeline import (  # noqa: F401
+    TacticianTrainingPipeline,
+    TacticianTrainingPipelineConfig,
+    TacticianTrainingPipelineResult,
+)
+
+__all__ = [
+    "AnalystPreMLConfig",
+    "AnalystPreMLOrchestrator",
+    "AnalystPreMLResult",
+    "AnalystTrainingPipeline",
+    "AnalystTrainingPipelineConfig",
+    "AnalystTrainingPipelineResult",
+    "TacticianPreMLConfig",
+    "TacticianPreMLOrchestrator",
+    "TacticianPreMLResult",
+    "TacticianTrainingPipeline",
+    "TacticianTrainingPipelineConfig",
+    "TacticianTrainingPipelineResult",
+]


### PR DESCRIPTION
## Summary
- load analyst pre-ML inputs, persist engineered features, and expose regime metadata for later stages
- train analyst base and ensemble models with regime features, capture NAS/TAS artifacts, and emit ensemble predictions
- extend tactician stages to incorporate analyst signals and regime data while persisting model metrics and ensemble outputs

## Testing
- python -m compileall src/training/steps/model_training/sub_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e391bf5984832f8a48da203e3f41b2