### PR TITLE
Centralize indicator creation in feature engineering

### DIFF
--- a/src/analyst/unified_regime_classifier.py
+++ b/src/analyst/unified_regime_classifier.py
@@ -20,6 +20,13 @@ try:
 except ImportError:
     FEATURE_ENGINEER_AVAILABLE = False
 
+# Import centralized indicators
+try:
+    from src.training.steps.feature_engineering import calculate_rsi, calculate_macd
+    CENTRALIZED_INDICATORS_AVAILABLE = True
+except ImportError:
+    CENTRALIZED_INDICATORS_AVAILABLE = False
+
 try:
     from src.core.decorators import handles_errors
 except ImportError:
@@ -497,10 +504,21 @@ except ImportError:
 
     @handles_errors(exceptions=(Exception,), default_return = None, context='UnifiedRegimeClassifier._calculate_rsi')
     def _calculate_rsi(self, df: pd.DataFrame, period: int = 14) -> pd.DataFrame:
-        """Calculate RSI indicator using existing FeatureEngineer."""
-        if self.feature_engineer is not None:
-            df['rsi'] = self.feature_engineer._calculate_rsi(df['close'], period)
-        else:
+        """Calculate RSI indicator using centralized system."""
+        try:
+            if CENTRALIZED_INDICATORS_AVAILABLE:
+                df['rsi'] = calculate_rsi(df, period=period, price_column='close')
+            elif self.feature_engineer is not None:
+                df['rsi'] = self.feature_engineer._calculate_rsi(df['close'], period)
+            else:
+                # Fallback implementation
+                close_diff = df['close'].diff()
+                gain = close_diff.where(close_diff > 0, 0).rolling(window = period).mean()
+                loss = (-close_diff.where(close_diff < 0, 0)).rolling(window = period).mean()
+                rs = gain / loss
+                df['rsi'] = 100 - 100 / (1 + rs)
+        except Exception as e:
+            self.logger.warning(f"RSI calculation failed: {e}")
             # Fallback implementation
             close_diff = df['close'].diff()
             gain = close_diff.where(close_diff > 0, 0).rolling(window = period).mean()
@@ -511,13 +529,28 @@ except ImportError:
 
     @handles_errors(exceptions=(Exception,), default_return = None, context='UnifiedRegimeClassifier._calculate_macd')
     def _calculate_macd(self, df: pd.DataFrame, fast: int = 12, slow: int = 26, signal: int = 9) -> pd.DataFrame:
-        """Calculate MACD indicator using existing FeatureEngineer."""
-        if self.feature_engineer is not None:
-            macd_line, signal_line, histogram = self.feature_engineer._calculate_macd(df['close'], fast, slow, signal)
-            df['macd'] = macd_line
-            df['macd_signal'] = signal_line
-            df['macd_histogram'] = histogram
-        else:
+        """Calculate MACD indicator using centralized system."""
+        try:
+            if CENTRALIZED_INDICATORS_AVAILABLE:
+                macd_data = calculate_macd(df, fast=fast, slow=slow, signal=signal, price_column='close')
+                df['macd'] = macd_data['macd']
+                df['macd_signal'] = macd_data['signal']
+                df['macd_histogram'] = macd_data['histogram']
+            elif self.feature_engineer is not None:
+                macd_line, signal_line, histogram = self.feature_engineer._calculate_macd(df['close'], fast, slow, signal)
+                df['macd'] = macd_line
+                df['macd_signal'] = signal_line
+                df['macd_histogram'] = histogram
+            else:
+                # Fallback implementation
+                close_diff = df['close'].diff()
+                exp1 = close_diff.ewm(span = fast).mean()
+                exp2 = close_diff.ewm(span = slow).mean()
+                df['macd'] = exp1 - exp2
+                df['macd_signal'] = df['macd'].ewm(span = signal).mean()
+                df['macd_histogram'] = df['macd'] - df['macd_signal']
+        except Exception as e:
+            self.logger.warning(f"MACD calculation failed: {e}")
             # Fallback implementation
             close_diff = df['close'].diff()
             exp1 = close_diff.ewm(span = fast).mean()

--- a/src/training/steps/feature_engineering/__init__.py
+++ b/src/training/steps/feature_engineering/__init__.py
@@ -4,6 +4,29 @@ Feature Engineering Package
 This package contains feature engineering utilities for the training pipeline.
 """
 
+from .indicators import (
+    CentralizedIndicators,
+    IndicatorConfig,
+    get_centralized_indicators,
+    calculate_rsi,
+    calculate_macd,
+    calculate_stochastic,
+    calculate_williams_r,
+    calculate_cci,
+    calculate_adx,
+    get_all_indicators
+)
+
 __all__ = [
     "TacticianFeatureSelector",
+    "CentralizedIndicators",
+    "IndicatorConfig", 
+    "get_centralized_indicators",
+    "calculate_rsi",
+    "calculate_macd",
+    "calculate_stochastic",
+    "calculate_williams_r",
+    "calculate_cci",
+    "calculate_adx",
+    "get_all_indicators"
 ]

--- a/src/training/steps/feature_engineering/indicators.py
+++ b/src/training/steps/feature_engineering/indicators.py
@@ -1,0 +1,545 @@
+"""
+Centralized Technical Indicators Module
+
+This module provides centralized access to all technical indicators (RSI, MACD, etc.)
+through the feature bank system. All other modules should import indicators from here
+rather than calculating them directly.
+
+This ensures consistency and avoids code duplication across the codebase.
+"""
+
+import pandas as pd
+import numpy as np
+import logging
+from typing import Optional, Dict, Any, Union, List
+from dataclasses import dataclass
+
+# Import the feature bank system
+try:
+    from src.feature_generation.core.feature_bank import get_global_feature_bank, FeatureBank
+    from src.feature_generation.core.feature_generator import FeatureCategory
+    FEATURE_BANK_AVAILABLE = True
+except ImportError:
+    FEATURE_BANK_AVAILABLE = False
+    FeatureBank = None
+    FeatureCategory = None
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class IndicatorConfig:
+    """Configuration for technical indicators."""
+    rsi_period: int = 14
+    macd_fast: int = 12
+    macd_slow: int = 26
+    macd_signal: int = 9
+    stochastic_period: int = 14
+    stochastic_smooth_k: int = 3
+    stochastic_smooth_d: int = 3
+    williams_r_period: int = 14
+    cci_period: int = 20
+    adx_period: int = 14
+
+class CentralizedIndicators:
+    """
+    Centralized access to technical indicators through the feature bank system.
+    
+    This class provides a unified interface for accessing all technical indicators,
+    ensuring they are calculated consistently across the entire codebase.
+    """
+    
+    def __init__(self, config: Optional[IndicatorConfig] = None):
+        """
+        Initialize the centralized indicators system.
+        
+        Args:
+            config: Configuration for indicator parameters
+        """
+        self.config = config or IndicatorConfig()
+        self.feature_bank = None
+        self._initialize_feature_bank()
+    
+    def _initialize_feature_bank(self) -> None:
+        """Initialize the feature bank system."""
+        if not FEATURE_BANK_AVAILABLE:
+            logger.warning("Feature bank not available. Indicators will use fallback calculations.")
+            return
+        
+        try:
+            self.feature_bank = get_global_feature_bank()
+            logger.info("✅ Centralized indicators initialized with feature bank")
+        except Exception as e:
+            logger.warning(f"Failed to initialize feature bank: {e}. Using fallback calculations.")
+            self.feature_bank = None
+    
+    def calculate_rsi(self, 
+                     data: pd.DataFrame, 
+                     period: Optional[int] = None,
+                     price_column: str = 'close') -> pd.Series:
+        """
+        Calculate RSI (Relative Strength Index) indicator.
+        
+        Args:
+            data: DataFrame with OHLCV data
+            period: RSI period (defaults to config value)
+            price_column: Column name for price data
+            
+        Returns:
+            RSI values as pandas Series
+        """
+        period = period or self.config.rsi_period
+        
+        if self.feature_bank and FEATURE_BANK_AVAILABLE:
+            try:
+                # Use feature bank for RSI calculation
+                rsi_features = self.feature_bank.generate_specific_features(
+                    data, 
+                    features=[f'rsi_{period}']
+                )
+                if not rsi_features.empty and f'rsi_{period}' in rsi_features.columns:
+                    return rsi_features[f'rsi_{period}']
+            except Exception as e:
+                logger.warning(f"Feature bank RSI calculation failed: {e}. Using fallback.")
+        
+        # Fallback RSI calculation
+        return self._calculate_rsi_fallback(data[price_column], period)
+    
+    def calculate_macd(self, 
+                      data: pd.DataFrame,
+                      fast: Optional[int] = None,
+                      slow: Optional[int] = None,
+                      signal: Optional[int] = None,
+                      price_column: str = 'close') -> Dict[str, pd.Series]:
+        """
+        Calculate MACD (Moving Average Convergence Divergence) indicator.
+        
+        Args:
+            data: DataFrame with OHLCV data
+            fast: Fast EMA period (defaults to config value)
+            slow: Slow EMA period (defaults to config value)
+            signal: Signal line period (defaults to config value)
+            price_column: Column name for price data
+            
+        Returns:
+            Dictionary with 'macd', 'signal', and 'histogram' Series
+        """
+        fast = fast or self.config.macd_fast
+        slow = slow or self.config.macd_slow
+        signal = signal or self.config.macd_signal
+        
+        if self.feature_bank and FEATURE_BANK_AVAILABLE:
+            try:
+                # Use feature bank for MACD calculation
+                macd_features = self.feature_bank.generate_specific_features(
+                    data,
+                    features=[f'macd_{fast}_{slow}', f'macd_signal_{fast}_{slow}_{signal}', f'macd_histogram_{fast}_{slow}_{signal}']
+                )
+                if not macd_features.empty:
+                    result = {}
+                    if f'macd_{fast}_{slow}' in macd_features.columns:
+                        result['macd'] = macd_features[f'macd_{fast}_{slow}']
+                    if f'macd_signal_{fast}_{slow}_{signal}' in macd_features.columns:
+                        result['signal'] = macd_features[f'macd_signal_{fast}_{slow}_{signal}']
+                    if f'macd_histogram_{fast}_{slow}_{signal}' in macd_features.columns:
+                        result['histogram'] = macd_features[f'macd_histogram_{fast}_{slow}_{signal}']
+                    
+                    if result:
+                        return result
+            except Exception as e:
+                logger.warning(f"Feature bank MACD calculation failed: {e}. Using fallback.")
+        
+        # Fallback MACD calculation
+        return self._calculate_macd_fallback(data[price_column], fast, slow, signal)
+    
+    def calculate_stochastic(self, 
+                           data: pd.DataFrame,
+                           period: Optional[int] = None,
+                           smooth_k: Optional[int] = None,
+                           smooth_d: Optional[int] = None) -> Dict[str, pd.Series]:
+        """
+        Calculate Stochastic Oscillator indicator.
+        
+        Args:
+            data: DataFrame with OHLCV data
+            period: Stochastic period (defaults to config value)
+            smooth_k: K smoothing period (defaults to config value)
+            smooth_d: D smoothing period (defaults to config value)
+            
+        Returns:
+            Dictionary with 'k' and 'd' Series
+        """
+        period = period or self.config.stochastic_period
+        smooth_k = smooth_k or self.config.stochastic_smooth_k
+        smooth_d = smooth_d or self.config.stochastic_smooth_d
+        
+        if self.feature_bank and FEATURE_BANK_AVAILABLE:
+            try:
+                # Use feature bank for Stochastic calculation
+                stoch_features = self.feature_bank.generate_specific_features(
+                    data,
+                    features=[f'stochastic_k_{period}_{smooth_k}', f'stochastic_d_{period}_{smooth_k}_{smooth_d}']
+                )
+                if not stoch_features.empty:
+                    result = {}
+                    if f'stochastic_k_{period}_{smooth_k}' in stoch_features.columns:
+                        result['k'] = stoch_features[f'stochastic_k_{period}_{smooth_k}']
+                    if f'stochastic_d_{period}_{smooth_k}_{smooth_d}' in stoch_features.columns:
+                        result['d'] = stoch_features[f'stochastic_d_{period}_{smooth_k}_{smooth_d}']
+                    
+                    if result:
+                        return result
+            except Exception as e:
+                logger.warning(f"Feature bank Stochastic calculation failed: {e}. Using fallback.")
+        
+        # Fallback Stochastic calculation
+        return self._calculate_stochastic_fallback(data, period, smooth_k, smooth_d)
+    
+    def calculate_williams_r(self, 
+                           data: pd.DataFrame,
+                           period: Optional[int] = None) -> pd.Series:
+        """
+        Calculate Williams %R indicator.
+        
+        Args:
+            data: DataFrame with OHLCV data
+            period: Williams %R period (defaults to config value)
+            
+        Returns:
+            Williams %R values as pandas Series
+        """
+        period = period or self.config.williams_r_period
+        
+        if self.feature_bank and FEATURE_BANK_AVAILABLE:
+            try:
+                # Use feature bank for Williams %R calculation
+                williams_features = self.feature_bank.generate_specific_features(
+                    data,
+                    features=[f'williams_r_{period}']
+                )
+                if not williams_features.empty and f'williams_r_{period}' in williams_features.columns:
+                    return williams_features[f'williams_r_{period}']
+            except Exception as e:
+                logger.warning(f"Feature bank Williams %R calculation failed: {e}. Using fallback.")
+        
+        # Fallback Williams %R calculation
+        return self._calculate_williams_r_fallback(data, period)
+    
+    def calculate_cci(self, 
+                     data: pd.DataFrame,
+                     period: Optional[int] = None) -> pd.Series:
+        """
+        Calculate Commodity Channel Index (CCI) indicator.
+        
+        Args:
+            data: DataFrame with OHLCV data
+            period: CCI period (defaults to config value)
+            
+        Returns:
+            CCI values as pandas Series
+        """
+        period = period or self.config.cci_period
+        
+        if self.feature_bank and FEATURE_BANK_AVAILABLE:
+            try:
+                # Use feature bank for CCI calculation
+                cci_features = self.feature_bank.generate_specific_features(
+                    data,
+                    features=[f'cci_{period}']
+                )
+                if not cci_features.empty and f'cci_{period}' in cci_features.columns:
+                    return cci_features[f'cci_{period}']
+            except Exception as e:
+                logger.warning(f"Feature bank CCI calculation failed: {e}. Using fallback.")
+        
+        # Fallback CCI calculation
+        return self._calculate_cci_fallback(data, period)
+    
+    def calculate_adx(self, 
+                     data: pd.DataFrame,
+                     period: Optional[int] = None) -> pd.Series:
+        """
+        Calculate Average Directional Index (ADX) indicator.
+        
+        Args:
+            data: DataFrame with OHLCV data
+            period: ADX period (defaults to config value)
+            
+        Returns:
+            ADX values as pandas Series
+        """
+        period = period or self.config.adx_period
+        
+        if self.feature_bank and FEATURE_BANK_AVAILABLE:
+            try:
+                # Use feature bank for ADX calculation
+                adx_features = self.feature_bank.generate_specific_features(
+                    data,
+                    features=[f'adx_{period}']
+                )
+                if not adx_features.empty and f'adx_{period}' in adx_features.columns:
+                    return adx_features[f'adx_{period}']
+            except Exception as e:
+                logger.warning(f"Feature bank ADX calculation failed: {e}. Using fallback.")
+        
+        # Fallback ADX calculation
+        return self._calculate_adx_fallback(data, period)
+    
+    def get_all_indicators(self, 
+                          data: pd.DataFrame,
+                          indicators: Optional[List[str]] = None) -> pd.DataFrame:
+        """
+        Get all available indicators for the given data.
+        
+        Args:
+            data: DataFrame with OHLCV data
+            indicators: List of indicator names to calculate (None for all)
+            
+        Returns:
+            DataFrame with all indicator values
+        """
+        if indicators is None:
+            indicators = ['rsi', 'macd', 'stochastic', 'williams_r', 'cci', 'adx']
+        
+        results = {}
+        
+        for indicator in indicators:
+            try:
+                if indicator == 'rsi':
+                    results[f'rsi_{self.config.rsi_period}'] = self.calculate_rsi(data)
+                elif indicator == 'macd':
+                    macd_data = self.calculate_macd(data)
+                    results.update(macd_data)
+                elif indicator == 'stochastic':
+                    stoch_data = self.calculate_stochastic(data)
+                    results.update(stoch_data)
+                elif indicator == 'williams_r':
+                    results[f'williams_r_{self.config.williams_r_period}'] = self.calculate_williams_r(data)
+                elif indicator == 'cci':
+                    results[f'cci_{self.config.cci_period}'] = self.calculate_cci(data)
+                elif indicator == 'adx':
+                    results[f'adx_{self.config.adx_period}'] = self.calculate_adx(data)
+            except Exception as e:
+                logger.warning(f"Failed to calculate {indicator}: {e}")
+        
+        return pd.DataFrame(results, index=data.index)
+    
+    # Fallback calculation methods
+    def _calculate_rsi_fallback(self, prices: pd.Series, period: int) -> pd.Series:
+        """Fallback RSI calculation."""
+        delta = prices.diff()
+        gain = (delta.where(delta > 0, 0)).rolling(window=period).mean()
+        loss = (-delta.where(delta < 0, 0)).rolling(window=period).mean()
+        rs = gain / loss
+        rsi = 100 - (100 / (1 + rs))
+        return rsi.fillna(50)  # Fill NaN with neutral value
+    
+    def _calculate_macd_fallback(self, prices: pd.Series, fast: int, slow: int, signal: int) -> Dict[str, pd.Series]:
+        """Fallback MACD calculation."""
+        ema_fast = prices.ewm(span=fast).mean()
+        ema_slow = prices.ewm(span=slow).mean()
+        macd = ema_fast - ema_slow
+        signal_line = macd.ewm(span=signal).mean()
+        histogram = macd - signal_line
+        
+        return {
+            'macd': macd,
+            'signal': signal_line,
+            'histogram': histogram
+        }
+    
+    def _calculate_stochastic_fallback(self, data: pd.DataFrame, period: int, smooth_k: int, smooth_d: int) -> Dict[str, pd.Series]:
+        """Fallback Stochastic calculation."""
+        low_min = data['low'].rolling(window=period).min()
+        high_max = data['high'].rolling(window=period).max()
+        
+        k = 100 * ((data['close'] - low_min) / (high_max - low_min))
+        k_smooth = k.rolling(window=smooth_k).mean()
+        d_smooth = k_smooth.rolling(window=smooth_d).mean()
+        
+        return {
+            'k': k_smooth,
+            'd': d_smooth
+        }
+    
+    def _calculate_williams_r_fallback(self, data: pd.DataFrame, period: int) -> pd.Series:
+        """Fallback Williams %R calculation."""
+        high_max = data['high'].rolling(window=period).max()
+        low_min = data['low'].rolling(window=period).min()
+        williams_r = -100 * ((high_max - data['close']) / (high_max - low_min))
+        return williams_r.fillna(-50)  # Fill NaN with neutral value
+    
+    def _calculate_cci_fallback(self, data: pd.DataFrame, period: int) -> pd.Series:
+        """Fallback CCI calculation."""
+        typical_price = (data['high'] + data['low'] + data['close']) / 3
+        sma_tp = typical_price.rolling(window=period).mean()
+        mad = typical_price.rolling(window=period).apply(lambda x: np.mean(np.abs(x - x.mean())))
+        cci = (typical_price - sma_tp) / (0.015 * mad)
+        return cci.fillna(0)  # Fill NaN with neutral value
+    
+    def _calculate_adx_fallback(self, data: pd.DataFrame, period: int) -> pd.Series:
+        """Fallback ADX calculation."""
+        high = data['high']
+        low = data['low']
+        close = data['close']
+        
+        # Calculate True Range
+        tr1 = high - low
+        tr2 = abs(high - close.shift(1))
+        tr3 = abs(low - close.shift(1))
+        tr = pd.concat([tr1, tr2, tr3], axis=1).max(axis=1)
+        
+        # Calculate Directional Movement
+        dm_plus = high.diff()
+        dm_minus = -low.diff()
+        
+        dm_plus = dm_plus.where((dm_plus > dm_minus) & (dm_plus > 0), 0)
+        dm_minus = dm_minus.where((dm_minus > dm_plus) & (dm_minus > 0), 0)
+        
+        # Calculate smoothed values
+        atr = tr.rolling(window=period).mean()
+        di_plus = 100 * (dm_plus.rolling(window=period).mean() / atr)
+        di_minus = 100 * (dm_minus.rolling(window=period).mean() / atr)
+        
+        # Calculate ADX
+        dx = 100 * abs(di_plus - di_minus) / (di_plus + di_minus)
+        adx = dx.rolling(window=period).mean()
+        
+        return adx.fillna(25)  # Fill NaN with neutral value
+
+# Global instance for easy access
+_global_indicators: Optional[CentralizedIndicators] = None
+
+def get_centralized_indicators(config: Optional[IndicatorConfig] = None) -> CentralizedIndicators:
+    """
+    Get the global centralized indicators instance.
+    
+    Args:
+        config: Optional configuration for indicators
+        
+    Returns:
+        CentralizedIndicators instance
+    """
+    global _global_indicators
+    
+    if _global_indicators is None:
+        _global_indicators = CentralizedIndicators(config)
+    
+    return _global_indicators
+
+def calculate_rsi(data: pd.DataFrame, period: int = 14, price_column: str = 'close') -> pd.Series:
+    """
+    Convenience function to calculate RSI.
+    
+    Args:
+        data: DataFrame with OHLCV data
+        period: RSI period
+        price_column: Column name for price data
+        
+    Returns:
+        RSI values as pandas Series
+    """
+    indicators = get_centralized_indicators()
+    return indicators.calculate_rsi(data, period, price_column)
+
+def calculate_macd(data: pd.DataFrame, fast: int = 12, slow: int = 26, signal: int = 9, price_column: str = 'close') -> Dict[str, pd.Series]:
+    """
+    Convenience function to calculate MACD.
+    
+    Args:
+        data: DataFrame with OHLCV data
+        fast: Fast EMA period
+        slow: Slow EMA period
+        signal: Signal line period
+        price_column: Column name for price data
+        
+    Returns:
+        Dictionary with 'macd', 'signal', and 'histogram' Series
+    """
+    indicators = get_centralized_indicators()
+    return indicators.calculate_macd(data, fast, slow, signal, price_column)
+
+def calculate_stochastic(data: pd.DataFrame, period: int = 14, smooth_k: int = 3, smooth_d: int = 3) -> Dict[str, pd.Series]:
+    """
+    Convenience function to calculate Stochastic Oscillator.
+    
+    Args:
+        data: DataFrame with OHLCV data
+        period: Stochastic period
+        smooth_k: K smoothing period
+        smooth_d: D smoothing period
+        
+    Returns:
+        Dictionary with 'k' and 'd' Series
+    """
+    indicators = get_centralized_indicators()
+    return indicators.calculate_stochastic(data, period, smooth_k, smooth_d)
+
+def calculate_williams_r(data: pd.DataFrame, period: int = 14) -> pd.Series:
+    """
+    Convenience function to calculate Williams %R.
+    
+    Args:
+        data: DataFrame with OHLCV data
+        period: Williams %R period
+        
+    Returns:
+        Williams %R values as pandas Series
+    """
+    indicators = get_centralized_indicators()
+    return indicators.calculate_williams_r(data, period)
+
+def calculate_cci(data: pd.DataFrame, period: int = 20) -> pd.Series:
+    """
+    Convenience function to calculate CCI.
+    
+    Args:
+        data: DataFrame with OHLCV data
+        period: CCI period
+        
+    Returns:
+        CCI values as pandas Series
+    """
+    indicators = get_centralized_indicators()
+    return indicators.calculate_cci(data, period)
+
+def calculate_adx(data: pd.DataFrame, period: int = 14) -> pd.Series:
+    """
+    Convenience function to calculate ADX.
+    
+    Args:
+        data: DataFrame with OHLCV data
+        period: ADX period
+        
+    Returns:
+        ADX values as pandas Series
+    """
+    indicators = get_centralized_indicators()
+    return indicators.calculate_adx(data, period)
+
+def get_all_indicators(data: pd.DataFrame, indicators: Optional[List[str]] = None) -> pd.DataFrame:
+    """
+    Convenience function to get all indicators.
+    
+    Args:
+        data: DataFrame with OHLCV data
+        indicators: List of indicator names to calculate (None for all)
+        
+    Returns:
+        DataFrame with all indicator values
+    """
+    indicators_obj = get_centralized_indicators()
+    return indicators_obj.get_all_indicators(data, indicators)
+
+# Export the main classes and functions
+__all__ = [
+    'CentralizedIndicators',
+    'IndicatorConfig',
+    'get_centralized_indicators',
+    'calculate_rsi',
+    'calculate_macd',
+    'calculate_stochastic',
+    'calculate_williams_r',
+    'calculate_cci',
+    'calculate_adx',
+    'get_all_indicators'
+]

--- a/src/training/steps/model_training/simplified/hmm_training.py
+++ b/src/training/steps/model_training/simplified/hmm_training.py
@@ -27,6 +27,7 @@ from src.utils.tprint import (
     tprint_debug, tprint_progress, tprint_performance, tprint_structured,
     tprint_timer, LogLevel
 )
+from src.training.steps.feature_engineering import calculate_rsi, calculate_macd
 
 logger = get_system_logger().getChild('HMMTrainingPipeline')
 
@@ -389,47 +390,45 @@ class HMMTrainingPipeline:
 
 
     def _calculate_rsi(self, prices: pd.Series, period: int = 14) -> pd.Series:
-        """Calculate RSI indicator."""
+        """Calculate RSI indicator using centralized system."""
         try:
-            delta = prices.diff()
-            gain = (delta.where(delta > 0, 0)).rolling(window=period).mean()
-            loss = (-delta.where(delta < 0, 0)).rolling(window=period).mean()
-            rs = gain / loss
-            rsi = 100 - (100 / (1 + rs))
-            return rsi
-        except (ValueError, ZeroDivisionError, IndexError) as e:
+            # Create a DataFrame with the prices for the centralized system
+            data = pd.DataFrame({'close': prices})
+            return calculate_rsi(data, period=period, price_column='close')
+        except Exception as e:
             self.logger.warning(f"RSI calculation failed: {e}")
             return pd.Series([50] * len(prices), index=prices.index)
 
     def _calculate_macd(self, prices: pd.Series, fast: int = 12, slow: int = 26) -> pd.Series:
-        """Calculate MACD indicator."""
+        """Calculate MACD indicator using centralized system."""
         try:
-            ema_fast = prices.ewm(span=fast).mean()
-            ema_slow = prices.ewm(span=slow).mean()
-            macd = ema_fast - ema_slow
-            return macd
-        except (ValueError, IndexError, TypeError) as e:
+            # Create a DataFrame with the prices for the centralized system
+            data = pd.DataFrame({'close': prices})
+            macd_data = calculate_macd(data, fast=fast, slow=slow, price_column='close')
+            return macd_data['macd']
+        except Exception as e:
             self.logger.warning(f"MACD calculation failed: {e}")
             return pd.Series([0] * len(prices), index=prices.index)
 
     def _calculate_macd_signal(self, prices: pd.Series, signal: int = 9) -> pd.Series:
-        """Calculate MACD signal line."""
+        """Calculate MACD signal line using centralized system."""
         try:
-            macd = self._calculate_macd(prices)
-            signal_line = macd.ewm(span=signal).mean()
-            return signal_line
-        except (ValueError, IndexError, TypeError) as e:
+            # Create a DataFrame with the prices for the centralized system
+            data = pd.DataFrame({'close': prices})
+            macd_data = calculate_macd(data, signal=signal, price_column='close')
+            return macd_data['signal']
+        except Exception as e:
             self.logger.warning(f"MACD signal calculation failed: {e}")
             return pd.Series([0] * len(prices), index=prices.index)
 
     def _calculate_macd_histogram(self, prices: pd.Series) -> pd.Series:
-        """Calculate MACD histogram."""
+        """Calculate MACD histogram using centralized system."""
         try:
-            macd = self._calculate_macd(prices)
-            signal = self._calculate_macd_signal(prices)
-            histogram = macd - signal
-            return histogram
-        except (ValueError, IndexError, TypeError) as e:
+            # Create a DataFrame with the prices for the centralized system
+            data = pd.DataFrame({'close': prices})
+            macd_data = calculate_macd(data, price_column='close')
+            return macd_data['histogram']
+        except Exception as e:
             self.logger.warning(f"MACD histogram calculation failed: {e}")
             return pd.Series([0] * len(prices), index=prices.index)
 

--- a/src/utils/common_operations.py
+++ b/src/utils/common_operations.py
@@ -13,6 +13,7 @@ import asyncio
 import time
 import functools
 import shutil
+import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union, Callable
 from contextlib import contextmanager

--- a/test_centralized_indicators.py
+++ b/test_centralized_indicators.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Test script for centralized indicators system.
+
+This script tests that the centralized indicators work correctly
+and that files can import and use them properly.
+"""
+
+import pandas as pd
+import numpy as np
+import sys
+import os
+
+# Add the project root to the path
+sys.path.insert(0, os.path.abspath('.'))
+
+def test_centralized_indicators():
+    """Test the centralized indicators system."""
+    print("🧪 Testing Centralized Indicators System")
+    print("=" * 50)
+    
+    # Create sample data
+    np.random.seed(42)
+    dates = pd.date_range('2023-01-01', periods=100, freq='1H')
+    
+    # Generate realistic OHLCV data
+    close_prices = 100 + np.cumsum(np.random.randn(100) * 0.01)
+    high_prices = close_prices + np.random.rand(100) * 2
+    low_prices = close_prices - np.random.rand(100) * 2
+    open_prices = close_prices + np.random.randn(100) * 0.5
+    volume = np.random.randint(1000, 10000, 100)
+    
+    data = pd.DataFrame({
+        'open': open_prices,
+        'high': high_prices,
+        'low': low_prices,
+        'close': close_prices,
+        'volume': volume
+    }, index=dates)
+    
+    print(f"✅ Created sample data with {len(data)} rows")
+    print(f"📊 Data columns: {list(data.columns)}")
+    print(f"📈 Price range: {data['close'].min():.2f} - {data['close'].max():.2f}")
+    
+    try:
+        # Test importing centralized indicators
+        print("\n🔧 Testing imports...")
+        from src.training.steps.feature_engineering import (
+            calculate_rsi, calculate_macd, calculate_stochastic,
+            calculate_williams_r, calculate_cci, calculate_adx,
+            get_all_indicators, CentralizedIndicators, IndicatorConfig
+        )
+        print("✅ Successfully imported centralized indicators")
+        
+        # Test RSI calculation
+        print("\n📊 Testing RSI calculation...")
+        rsi = calculate_rsi(data, period=14)
+        print(f"✅ RSI calculated: {len(rsi)} values")
+        print(f"📈 RSI range: {rsi.min():.2f} - {rsi.max():.2f}")
+        print(f"📊 RSI sample values: {rsi.head().values}")
+        
+        # Test MACD calculation
+        print("\n📊 Testing MACD calculation...")
+        macd_data = calculate_macd(data, fast=12, slow=26, signal=9)
+        print(f"✅ MACD calculated: {len(macd_data)} components")
+        for key, series in macd_data.items():
+            print(f"📈 {key}: {len(series)} values, range: {series.min():.2f} - {series.max():.2f}")
+        
+        # Test Stochastic calculation
+        print("\n📊 Testing Stochastic calculation...")
+        stoch_data = calculate_stochastic(data, period=14, smooth_k=3, smooth_d=3)
+        print(f"✅ Stochastic calculated: {len(stoch_data)} components")
+        for key, series in stoch_data.items():
+            print(f"📈 {key}: {len(series)} values, range: {series.min():.2f} - {series.max():.2f}")
+        
+        # Test Williams %R calculation
+        print("\n📊 Testing Williams %R calculation...")
+        williams_r = calculate_williams_r(data, period=14)
+        print(f"✅ Williams %R calculated: {len(williams_r)} values")
+        print(f"📈 Williams %R range: {williams_r.min():.2f} - {williams_r.max():.2f}")
+        
+        # Test CCI calculation
+        print("\n📊 Testing CCI calculation...")
+        cci = calculate_cci(data, period=20)
+        print(f"✅ CCI calculated: {len(cci)} values")
+        print(f"📈 CCI range: {cci.min():.2f} - {cci.max():.2f}")
+        
+        # Test ADX calculation
+        print("\n📊 Testing ADX calculation...")
+        adx = calculate_adx(data, period=14)
+        print(f"✅ ADX calculated: {len(adx)} values")
+        print(f"📈 ADX range: {adx.min():.2f} - {adx.max():.2f}")
+        
+        # Test getting all indicators
+        print("\n📊 Testing get_all_indicators...")
+        all_indicators = get_all_indicators(data, indicators=['rsi', 'macd', 'stochastic'])
+        print(f"✅ All indicators calculated: {len(all_indicators.columns)} features")
+        print(f"📊 Indicator columns: {list(all_indicators.columns)}")
+        
+        # Test CentralizedIndicators class
+        print("\n🔧 Testing CentralizedIndicators class...")
+        config = IndicatorConfig(rsi_period=21, macd_fast=15, macd_slow=30)
+        indicators = CentralizedIndicators(config)
+        
+        rsi_custom = indicators.calculate_rsi(data, period=21)
+        print(f"✅ Custom RSI (period=21): {len(rsi_custom)} values")
+        
+        macd_custom = indicators.calculate_macd(data, fast=15, slow=30)
+        print(f"✅ Custom MACD (15,30): {len(macd_custom)} components")
+        
+        print("\n🎉 All tests passed! Centralized indicators system is working correctly.")
+        return True
+        
+    except Exception as e:
+        print(f"\n❌ Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def test_updated_files():
+    """Test that updated files can use centralized indicators."""
+    print("\n🔧 Testing Updated Files")
+    print("=" * 30)
+    
+    try:
+        # Test HMM training pipeline
+        print("Testing HMM training pipeline...")
+        from src.training.steps.model_training.simplified.hmm_training import HMMTrainingPipeline
+        
+        # Create a small sample for testing
+        np.random.seed(42)
+        data = pd.DataFrame({
+            'close': 100 + np.cumsum(np.random.randn(50) * 0.01)
+        })
+        
+        pipeline = HMMTrainingPipeline()
+        rsi = pipeline._calculate_rsi(data['close'], period=14)
+        macd = pipeline._calculate_macd(data['close'], fast=12, slow=26)
+        
+        print(f"✅ HMM pipeline RSI: {len(rsi)} values")
+        print(f"✅ HMM pipeline MACD: {len(macd)} values")
+        
+        # Test unified regime classifier
+        print("Testing unified regime classifier...")
+        from src.analyst.unified_regime_classifier import UnifiedRegimeClassifier
+        
+        classifier = UnifiedRegimeClassifier()
+        test_df = pd.DataFrame({
+            'close': 100 + np.cumsum(np.random.randn(50) * 0.01),
+            'high': 100 + np.cumsum(np.random.randn(50) * 0.01) + 1,
+            'low': 100 + np.cumsum(np.random.randn(50) * 0.01) - 1
+        })
+        
+        rsi_df = classifier._calculate_rsi(test_df, period=14)
+        macd_df = classifier._calculate_macd(test_df, fast=12, slow=26, signal=9)
+        
+        print(f"✅ Regime classifier RSI: {len(rsi_df)} rows")
+        print(f"✅ Regime classifier MACD: {len(macd_df)} rows")
+        
+        print("\n🎉 Updated files are working correctly!")
+        return True
+        
+    except Exception as e:
+        print(f"\n❌ Updated files test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+if __name__ == "__main__":
+    print("🚀 Starting Centralized Indicators Test Suite")
+    print("=" * 60)
+    
+    # Test centralized indicators
+    indicators_ok = test_centralized_indicators()
+    
+    # Test updated files
+    files_ok = test_updated_files()
+    
+    print("\n" + "=" * 60)
+    if indicators_ok and files_ok:
+        print("🎉 ALL TESTS PASSED! Centralized indicators system is working correctly.")
+        print("✅ Indicators are now centralized in feature_engineering/indicators.py")
+        print("✅ Files have been updated to use the centralized system")
+        print("✅ Fallback calculations are available if feature bank is unavailable")
+    else:
+        print("❌ Some tests failed. Please check the errors above.")
+        sys.exit(1)

--- a/test_simple_indicators.py
+++ b/test_simple_indicators.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Simple test for centralized indicators system.
+
+This script tests the basic functionality without importing
+the complex feature generation system.
+"""
+
+import pandas as pd
+import numpy as np
+import sys
+import os
+
+# Add the project root to the path
+sys.path.insert(0, os.path.abspath('.'))
+
+def test_basic_indicators():
+    """Test basic indicator calculations without complex imports."""
+    print("🧪 Testing Basic Indicator Calculations")
+    print("=" * 50)
+    
+    # Create sample data
+    np.random.seed(42)
+    dates = pd.date_range('2023-01-01', periods=100, freq='1h')
+    
+    # Generate realistic OHLCV data
+    close_prices = 100 + np.cumsum(np.random.randn(100) * 0.01)
+    high_prices = close_prices + np.random.rand(100) * 2
+    low_prices = close_prices - np.random.rand(100) * 2
+    open_prices = close_prices + np.random.randn(100) * 0.5
+    volume = np.random.randint(1000, 10000, 100)
+    
+    data = pd.DataFrame({
+        'open': open_prices,
+        'high': high_prices,
+        'low': low_prices,
+        'close': close_prices,
+        'volume': volume
+    }, index=dates)
+    
+    print(f"✅ Created sample data with {len(data)} rows")
+    print(f"📊 Data columns: {list(data.columns)}")
+    print(f"📈 Price range: {data['close'].min():.2f} - {data['close'].max():.2f}")
+    
+    # Test basic RSI calculation
+    print("\n📊 Testing RSI calculation...")
+    def calculate_rsi_basic(prices, period=14):
+        delta = prices.diff()
+        gain = (delta.where(delta > 0, 0)).rolling(window=period).mean()
+        loss = (-delta.where(delta < 0, 0)).rolling(window=period).mean()
+        rs = gain / loss
+        rsi = 100 - (100 / (1 + rs))
+        return rsi.fillna(50)
+    
+    rsi = calculate_rsi_basic(data['close'], period=14)
+    print(f"✅ RSI calculated: {len(rsi)} values")
+    print(f"📈 RSI range: {rsi.min():.2f} - {rsi.max():.2f}")
+    print(f"📊 RSI sample values: {rsi.head().values}")
+    
+    # Test basic MACD calculation
+    print("\n📊 Testing MACD calculation...")
+    def calculate_macd_basic(prices, fast=12, slow=26, signal=9):
+        ema_fast = prices.ewm(span=fast).mean()
+        ema_slow = prices.ewm(span=slow).mean()
+        macd = ema_fast - ema_slow
+        signal_line = macd.ewm(span=signal).mean()
+        histogram = macd - signal_line
+        return {'macd': macd, 'signal': signal_line, 'histogram': histogram}
+    
+    macd_data = calculate_macd_basic(data['close'], fast=12, slow=26, signal=9)
+    print(f"✅ MACD calculated: {len(macd_data)} components")
+    for key, series in macd_data.items():
+        print(f"📈 {key}: {len(series)} values, range: {series.min():.2f} - {series.max():.2f}")
+    
+    # Test basic Stochastic calculation
+    print("\n📊 Testing Stochastic calculation...")
+    def calculate_stochastic_basic(data, period=14, smooth_k=3, smooth_d=3):
+        low_min = data['low'].rolling(window=period).min()
+        high_max = data['high'].rolling(window=period).max()
+        
+        k = 100 * ((data['close'] - low_min) / (high_max - low_min))
+        k_smooth = k.rolling(window=smooth_k).mean()
+        d_smooth = k_smooth.rolling(window=smooth_d).mean()
+        
+        return {'k': k_smooth, 'd': d_smooth}
+    
+    stoch_data = calculate_stochastic_basic(data, period=14, smooth_k=3, smooth_d=3)
+    print(f"✅ Stochastic calculated: {len(stoch_data)} components")
+    for key, series in stoch_data.items():
+        print(f"📈 {key}: {len(series)} values, range: {series.min():.2f} - {series.max():.2f}")
+    
+    print("\n🎉 Basic indicator calculations are working correctly!")
+    return True
+
+def test_centralized_indicators_simple():
+    """Test the centralized indicators module directly."""
+    print("\n🔧 Testing Centralized Indicators Module")
+    print("=" * 40)
+    
+    try:
+        # Import the indicators module directly
+        from src.training.steps.feature_engineering.indicators import (
+            CentralizedIndicators, IndicatorConfig, 
+            calculate_rsi, calculate_macd, calculate_stochastic,
+            calculate_williams_r, calculate_cci, calculate_adx
+        )
+        print("✅ Successfully imported centralized indicators module")
+        
+        # Create sample data
+        np.random.seed(42)
+        data = pd.DataFrame({
+            'open': 100 + np.random.randn(50) * 0.5,
+            'high': 100 + np.random.randn(50) * 0.5 + 1,
+            'low': 100 + np.random.randn(50) * 0.5 - 1,
+            'close': 100 + np.cumsum(np.random.randn(50) * 0.01),
+            'volume': np.random.randint(1000, 10000, 50)
+        })
+        
+        # Test individual functions
+        print("\n📊 Testing individual indicator functions...")
+        
+        rsi = calculate_rsi(data, period=14)
+        print(f"✅ RSI: {len(rsi)} values, range: {rsi.min():.2f} - {rsi.max():.2f}")
+        
+        macd_data = calculate_macd(data, fast=12, slow=26, signal=9)
+        print(f"✅ MACD: {len(macd_data)} components")
+        
+        stoch_data = calculate_stochastic(data, period=14)
+        print(f"✅ Stochastic: {len(stoch_data)} components")
+        
+        williams_r = calculate_williams_r(data, period=14)
+        print(f"✅ Williams %R: {len(williams_r)} values, range: {williams_r.min():.2f} - {williams_r.max():.2f}")
+        
+        cci = calculate_cci(data, period=20)
+        print(f"✅ CCI: {len(cci)} values, range: {cci.min():.2f} - {cci.max():.2f}")
+        
+        adx = calculate_adx(data, period=14)
+        print(f"✅ ADX: {len(adx)} values, range: {adx.min():.2f} - {adx.max():.2f}")
+        
+        # Test CentralizedIndicators class
+        print("\n🔧 Testing CentralizedIndicators class...")
+        config = IndicatorConfig(rsi_period=21, macd_fast=15, macd_slow=30)
+        indicators = CentralizedIndicators(config)
+        
+        rsi_custom = indicators.calculate_rsi(data, period=21)
+        print(f"✅ Custom RSI (period=21): {len(rsi_custom)} values")
+        
+        macd_custom = indicators.calculate_macd(data, fast=15, slow=30)
+        print(f"✅ Custom MACD (15,30): {len(macd_custom)} components")
+        
+        print("\n🎉 Centralized indicators module is working correctly!")
+        return True
+        
+    except Exception as e:
+        print(f"\n❌ Centralized indicators test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+if __name__ == "__main__":
+    print("🚀 Starting Simple Indicators Test Suite")
+    print("=" * 60)
+    
+    # Test basic calculations
+    basic_ok = test_basic_indicators()
+    
+    # Test centralized indicators
+    centralized_ok = test_centralized_indicators_simple()
+    
+    print("\n" + "=" * 60)
+    if basic_ok and centralized_ok:
+        print("🎉 ALL TESTS PASSED! Indicator calculations are working correctly.")
+        print("✅ Basic indicator calculations work")
+        print("✅ Centralized indicators module works")
+        print("✅ Fallback calculations are available")
+    else:
+        print("❌ Some tests failed. Please check the errors above.")
+        sys.exit(1)


### PR DESCRIPTION
Centralize indicator calculations into `feature_engineering/indicators.py` to ensure consistency and reduce code duplication across the codebase.

The new `indicators.py` module now serves as the single source for all technical indicators (RSI, MACD, etc.), leveraging the existing feature bank system when available, and providing robust fallback calculations otherwise. This refactoring updates existing modules like `unified_regime_classifier.py` and `hmm_training.py` to import these centralized functions, preventing redundant indicator implementations.

---
<a href="https://cursor.com/background-agent?bcId=bc-4cea91e2-8cc0-49b3-9441-4f600bc2e652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4cea91e2-8cc0-49b3-9441-4f600bc2e652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

