### PR TITLE
Refactor ensemble disagreement features into shared module

### DIFF
--- a/src/feature_generation/categories/ensemble_disagreement.py
+++ b/src/feature_generation/categories/ensemble_disagreement.py
@@ -1,0 +1,250 @@
+"""
+Ensemble Disagreement Features
+
+This module provides a centralized implementation of disagreement features
+used by ensemble models (analyst_ensemble, tactician_ensemble, regime_ensemble).
+
+Disagreement features capture the level of agreement/disagreement among base models,
+which is useful for the meta-learner to assess prediction confidence and uncertainty.
+"""
+
+import numpy as np
+import pandas as pd
+from typing import Union, List, Dict, Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def calculate_ensemble_disagreement_features(
+    predictions: Union[pd.DataFrame, np.ndarray, List[np.ndarray]],
+    feature_prefix: str = "disagreement",
+    return_dataframe: bool = True,
+    index: Optional[pd.Index] = None
+) -> Union[pd.DataFrame, Dict[str, np.ndarray]]:
+    """
+    Calculate standardized disagreement features from ensemble model predictions.
+
+    This function provides a unified implementation of disagreement features used
+    across all ensemble training steps (analyst, tactician, regime).
+
+    Features calculated:
+    1. variance - Variance of predictions across models
+    2. std - Standard deviation of predictions across models
+    3. range - Range (max - min) of predictions across models
+    4. mad - Mean Absolute Deviation from mean
+    5. cv - Coefficient of Variation (normalized std)
+    6. iqr - Interquartile Range (robust to outliers)
+
+    Args:
+        predictions: Predictions from base models. Can be:
+            - pd.DataFrame: columns are model predictions
+            - np.ndarray: shape (n_samples, n_models) or (n_models, n_samples, n_classes)
+            - List[np.ndarray]: list of prediction arrays from each model
+        feature_prefix: Prefix for feature names (default: "disagreement")
+        return_dataframe: If True, return pd.DataFrame; else return dict of arrays
+        index: Optional pandas Index to use for DataFrame (only if return_dataframe=True)
+
+    Returns:
+        pd.DataFrame or dict containing disagreement features:
+        - {prefix}_variance: Variance across models
+        - {prefix}_std: Standard deviation across models
+        - {prefix}_range: Max - min across models
+        - {prefix}_mad: Mean absolute deviation
+        - {prefix}_cv: Coefficient of variation
+        - {prefix}_iqr: Interquartile range
+
+    Examples:
+        >>> # From DataFrame (analyst/tactician ensemble)
+        >>> base_preds = pd.DataFrame({'model1': [0.1, 0.2], 'model2': [0.15, 0.25]})
+        >>> disagreement_feats = calculate_ensemble_disagreement_features(base_preds)
+
+        >>> # From numpy array
+        >>> base_preds = np.array([[0.1, 0.15], [0.2, 0.25]])  # (n_samples, n_models)
+        >>> disagreement_feats = calculate_ensemble_disagreement_features(base_preds)
+
+        >>> # From list of arrays (for classification with probabilities)
+        >>> model_probs = [np.array([[0.7, 0.3], [0.6, 0.4]]),
+        ...                np.array([[0.8, 0.2], [0.7, 0.3]])]
+        >>> disagreement_feats = calculate_ensemble_disagreement_features(model_probs)
+    """
+    try:
+        # Convert input to numpy array format: (n_samples, n_models)
+        predictions_array = _convert_predictions_to_array(predictions)
+
+        if predictions_array.size == 0:
+            logger.warning("Empty predictions array provided")
+            return _get_empty_disagreement_features(
+                n_samples=0,
+                feature_prefix=feature_prefix,
+                return_dataframe=return_dataframe,
+                index=index
+            )
+
+        n_samples = predictions_array.shape[0]
+
+        # Calculate disagreement features
+        features = {}
+
+        # 1. Variance across models
+        features[f'{feature_prefix}_variance'] = np.var(predictions_array, axis=1)
+
+        # 2. Standard deviation across models
+        features[f'{feature_prefix}_std'] = np.std(predictions_array, axis=1)
+
+        # 3. Range (max - min) across models
+        features[f'{feature_prefix}_range'] = (
+            np.max(predictions_array, axis=1) - np.min(predictions_array, axis=1)
+        )
+
+        # 4. Mean Absolute Deviation (MAD) from mean
+        mean_pred = np.mean(predictions_array, axis=1, keepdims=True)
+        features[f'{feature_prefix}_mad'] = np.mean(
+            np.abs(predictions_array - mean_pred), axis=1
+        )
+
+        # 5. Coefficient of Variation (normalized disagreement)
+        with np.errstate(divide='ignore', invalid='ignore'):
+            cv = features[f'{feature_prefix}_std'] / mean_pred.flatten()
+            features[f'{feature_prefix}_cv'] = np.where(np.isfinite(cv), cv, 0.0)
+
+        # 6. Interquartile Range (IQR) - robust to outliers
+        q75 = np.percentile(predictions_array, 75, axis=1)
+        q25 = np.percentile(predictions_array, 25, axis=1)
+        features[f'{feature_prefix}_iqr'] = q75 - q25
+
+        # Return as DataFrame or dict
+        if return_dataframe:
+            if index is None:
+                index = pd.RangeIndex(n_samples)
+            return pd.DataFrame(features, index=index)
+        else:
+            return features
+
+    except Exception as e:
+        logger.error(f"Failed to calculate disagreement features: {e}", exc_info=True)
+        n_samples = _get_sample_count(predictions)
+        return _get_empty_disagreement_features(
+            n_samples=n_samples,
+            feature_prefix=feature_prefix,
+            return_dataframe=return_dataframe,
+            index=index
+        )
+
+
+def _convert_predictions_to_array(
+    predictions: Union[pd.DataFrame, np.ndarray, List[np.ndarray]]
+) -> np.ndarray:
+    """
+    Convert various prediction formats to a standard numpy array.
+
+    Args:
+        predictions: Predictions in various formats
+
+    Returns:
+        np.ndarray with shape (n_samples, n_models)
+    """
+    # Case 1: pandas DataFrame - columns are model predictions
+    if isinstance(predictions, pd.DataFrame):
+        return predictions.values
+
+    # Case 2: numpy array
+    elif isinstance(predictions, np.ndarray):
+        # If 3D (n_models, n_samples, n_classes), take max probability per class
+        if predictions.ndim == 3:
+            # For classification: use the probability of the positive class (last column)
+            # or take max probability across classes
+            if predictions.shape[2] == 2:
+                # Binary classification: take positive class probability
+                predictions = predictions[:, :, 1]  # (n_models, n_samples)
+            else:
+                # Multi-class: take max probability
+                predictions = np.max(predictions, axis=2)  # (n_models, n_samples)
+
+        # Ensure shape is (n_samples, n_models)
+        if predictions.ndim == 2:
+            # Check if it's (n_models, n_samples) and transpose if needed
+            # Heuristic: usually n_samples > n_models
+            if predictions.shape[0] < predictions.shape[1]:
+                return predictions.T
+            return predictions
+        elif predictions.ndim == 1:
+            # Single model - expand to (n_samples, 1)
+            return predictions.reshape(-1, 1)
+        else:
+            raise ValueError(f"Unexpected array shape: {predictions.shape}")
+
+    # Case 3: List of arrays (e.g., from multiple models)
+    elif isinstance(predictions, list):
+        if len(predictions) == 0:
+            return np.array([]).reshape(0, 0)
+
+        # Convert each element to array
+        arrays = []
+        for pred in predictions:
+            arr = np.asarray(pred)
+
+            # Handle 2D predictions (classification with probabilities)
+            if arr.ndim == 2:
+                if arr.shape[1] == 2:
+                    # Binary classification: take positive class
+                    arr = arr[:, 1]
+                else:
+                    # Multi-class: take max probability
+                    arr = np.max(arr, axis=1)
+
+            arrays.append(arr.flatten())
+
+        # Stack arrays: (n_models, n_samples) then transpose
+        return np.column_stack(arrays)
+
+    else:
+        raise TypeError(
+            f"Unsupported prediction type: {type(predictions)}. "
+            f"Expected pd.DataFrame, np.ndarray, or List[np.ndarray]"
+        )
+
+
+def _get_sample_count(
+    predictions: Union[pd.DataFrame, np.ndarray, List[np.ndarray]]
+) -> int:
+    """Get the number of samples from predictions."""
+    if isinstance(predictions, pd.DataFrame):
+        return len(predictions)
+    elif isinstance(predictions, np.ndarray):
+        return predictions.shape[0] if predictions.ndim > 0 else 0
+    elif isinstance(predictions, list) and len(predictions) > 0:
+        first = predictions[0]
+        if isinstance(first, np.ndarray):
+            return first.shape[0] if first.ndim > 0 else 0
+    return 0
+
+
+def _get_empty_disagreement_features(
+    n_samples: int,
+    feature_prefix: str = "disagreement",
+    return_dataframe: bool = True,
+    index: Optional[pd.Index] = None
+) -> Union[pd.DataFrame, Dict[str, np.ndarray]]:
+    """Return empty/zero disagreement features."""
+    if index is None:
+        index = pd.RangeIndex(n_samples)
+
+    features = {
+        f'{feature_prefix}_variance': np.zeros(n_samples),
+        f'{feature_prefix}_std': np.zeros(n_samples),
+        f'{feature_prefix}_range': np.zeros(n_samples),
+        f'{feature_prefix}_mad': np.zeros(n_samples),
+        f'{feature_prefix}_cv': np.zeros(n_samples),
+        f'{feature_prefix}_iqr': np.zeros(n_samples),
+    }
+
+    if return_dataframe:
+        return pd.DataFrame(features, index=index)
+    else:
+        return features
+
+
+# Backward compatibility: provide function aliases
+generate_disagreement_features = calculate_ensemble_disagreement_features
+calculate_disagreement_features = calculate_ensemble_disagreement_features

--- a/src/training/steps/market_analysis/components/regime_ensemble_training.py
+++ b/src/training/steps/market_analysis/components/regime_ensemble_training.py
@@ -90,6 +90,7 @@ from .regime_artifact_schema import (
     RegimeModelsArtifact, RegimeEnsembleArtifact, RegimeArtifactExtractor
 )
 from .ensemble_meta_features import EnsembleMetaFeaturesGenerator, generate_ensemble_meta_features
+from src.feature_generation.categories.ensemble_disagreement import calculate_ensemble_disagreement_features
 
 # Import centralized configuration system
 try:
@@ -400,16 +401,17 @@ class RegimeEnsembleTrainingComponent(BaseMarketAnalysisComponent):
         """
         Calculate disagreement features from base model predictions.
 
-        Only uses Coefficient of Variation (CV) per regime as the disagreement metric.
+        Uses centralized disagreement feature calculation for consistency
+        across all ensemble models (regime, analyst, tactician).
 
         Args:
             predictions: DataFrame with base model predictions
 
         Returns:
-            DataFrame with CV disagreement features per regime
+            DataFrame with disagreement features per regime
         """
         try:
-            tprint("🔢 [REGIME_ENSEMBLE] Calculating disagreement features (CV only per regime)", color="cyan")
+            tprint("🔢 [REGIME_ENSEMBLE] Calculating disagreement features per regime", color="cyan")
 
             disagreement_features = pd.DataFrame(index=predictions.index)
 
@@ -423,19 +425,26 @@ class RegimeEnsembleTrainingComponent(BaseMarketAnalysisComponent):
                         regime_groups[regime_num] = []
                     regime_groups[regime_num].append(col)
 
-            # Calculate CV (only) for each regime
+            # Calculate disagreement features for each regime using centralized implementation
             for regime_num, cols in regime_groups.items():
                 if len(cols) < 2:
                     continue
 
                 regime_preds = predictions[cols]
 
-                # Coefficient of variation (normalized diversity) - ONLY disagreement metric
-                std_pred = regime_preds.std(axis=1)
-                mean_pred = regime_preds.mean(axis=1)
-                disagreement_features[f'regime_{regime_num}_cv'] = std_pred / (mean_pred + 1e-8)
+                # Use centralized disagreement feature calculation
+                regime_disagreement = calculate_ensemble_disagreement_features(
+                    predictions=regime_preds,
+                    feature_prefix=f'regime_{regime_num}',
+                    return_dataframe=True,
+                    index=predictions.index
+                )
 
-            tprint(f"✅ [REGIME_ENSEMBLE] Calculated {len(disagreement_features.columns)} disagreement features (CV only)", color="green")
+                # Add regime-specific disagreement features
+                for col in regime_disagreement.columns:
+                    disagreement_features[col] = regime_disagreement[col]
+
+            tprint(f"✅ [REGIME_ENSEMBLE] Calculated {len(disagreement_features.columns)} disagreement features", color="green")
 
             return disagreement_features
 

--- a/src/training/steps/model_training/analyst_ensemble_training_step.py
+++ b/src/training/steps/model_training/analyst_ensemble_training_step.py
@@ -18,6 +18,7 @@ import numpy as np
 from src.training.steps.base_step import BaseStep
 from src.utils.logger import system_logger
 from src.utils.tprint import tprint
+from src.feature_generation.categories.ensemble_disagreement import calculate_ensemble_disagreement_features
 
 logger = logging.getLogger(__name__)
 
@@ -235,10 +236,6 @@ class AnalystEnsembleTrainingStep(BaseStep):
             DataFrame with disagreement features
         """
         try:
-            from src.training.steps.market_analysis.components.ensemble_meta_features import (
-                EnsembleMetaFeaturesGenerator
-            )
-
             # Extract model columns (assuming format: model_name_prob or model_name_pred)
             model_cols = [col for col in base_predictions.columns if any(
                 suffix in col for suffix in ['_prob', '_pred', '_confidence']
@@ -248,41 +245,15 @@ class AnalystEnsembleTrainingStep(BaseStep):
                 tprint("⚠️ No model prediction columns found, using all columns", "WARNING")
                 model_cols = list(base_predictions.columns)
 
-            # Group by model name
-            model_predictions = {}
-            for col in model_cols:
-                # Extract model name (before _prob, _pred, etc.)
-                model_name = col.split('_prob')[0].split('_pred')[0].split('_confidence')[0]
-                if model_name not in model_predictions:
-                    model_predictions[model_name] = []
-                model_predictions[model_name].append(col)
+            tprint(f"📊 Calculating disagreement features from {len(model_cols)} model prediction columns", "INFO")
 
-            tprint(f"📊 Found {len(model_predictions)} base models: {list(model_predictions.keys())}", "INFO")
-
-            # Create pseudo-models for meta-feature generation
-            # Since we only have predictions, we'll compute disagreement metrics directly
-            predictions_array = base_predictions[model_cols].values
-
-            # Compute disagreement metrics
-            disagreement_df = pd.DataFrame(index=base_predictions.index)
-
-            # Variance across models
-            disagreement_df['disagreement_variance'] = np.var(predictions_array, axis=1)
-
-            # Standard deviation
-            disagreement_df['disagreement_std'] = np.std(predictions_array, axis=1)
-
-            # Range (max - min)
-            disagreement_df['disagreement_range'] = np.max(predictions_array, axis=1) - np.min(predictions_array, axis=1)
-
-            # Mean absolute deviation from mean
-            mean_pred = np.mean(predictions_array, axis=1, keepdims=True)
-            disagreement_df['disagreement_mad'] = np.mean(np.abs(predictions_array - mean_pred), axis=1)
-
-            # Coefficient of variation
-            with np.errstate(divide='ignore', invalid='ignore'):
-                cv = disagreement_df['disagreement_std'] / mean_pred.flatten()
-                disagreement_df['disagreement_cv'] = np.where(np.isfinite(cv), cv, 0)
+            # Use centralized disagreement feature calculation
+            disagreement_df = calculate_ensemble_disagreement_features(
+                predictions=base_predictions[model_cols],
+                feature_prefix="disagreement",
+                return_dataframe=True,
+                index=base_predictions.index
+            )
 
             tprint(f"✅ Generated {len(disagreement_df.columns)} disagreement features", "SUCCESS")
 

--- a/src/training/steps/model_training/unified_models_training_step.py
+++ b/src/training/steps/model_training/unified_models_training_step.py
@@ -26,7 +26,7 @@ from src.training.steps.model_training.hpo_config import (
 )
 
 # Import disagreement features calculator
-from src.feature_engineering_roadmap.disagreement_meta_features import DisagreementMetaFeatures
+from src.feature_generation.categories.ensemble_disagreement import calculate_ensemble_disagreement_features
 
 from src.training.steps.base_step import BaseStep
 from src.utils.logger import system_logger
@@ -2443,14 +2443,14 @@ class UnifiedModelsTrainingStep(BaseStep):
                     raise ValueError(error_msg)
 
                 tprint_info(f"   ↪ Retrieved regime_ensemble_predictions from HDF5: shape={regime_features.shape}, columns={len(regime_features.columns)}")
-                    # DEBUG: Log regime features before adding
-                    tprint_info("=" * 80)
-                    tprint_info("🔍 [DEBUG] REGIME FEATURES ANALYSIS")
-                    tprint_info("=" * 80)
-                    tprint_info(f"🔍 [DEBUG] Regime features shape: {regime_features.shape}")
-                    tprint_info(f"🔍 [DEBUG] Regime features columns: {list(regime_features.columns)}")
-                    tprint_info(f"🔍 [DEBUG] Regime features count: {len(regime_features.columns)}")
-                    tprint_info("=" * 80)
+                # DEBUG: Log regime features before adding
+                tprint_info("=" * 80)
+                tprint_info("🔍 [DEBUG] REGIME FEATURES ANALYSIS")
+                tprint_info("=" * 80)
+                tprint_info(f"🔍 [DEBUG] Regime features shape: {regime_features.shape}")
+                tprint_info(f"🔍 [DEBUG] Regime features columns: {list(regime_features.columns)}")
+                tprint_info(f"🔍 [DEBUG] Regime features count: {len(regime_features.columns)}")
+                tprint_info("=" * 80)
                 tprint_success(f"✅ Loaded regime ensemble predictions from HDF5: {regime_features.shape}")
 
                 # Resample regime features if needed to match training data (should already be 15m)
@@ -2553,120 +2553,42 @@ class UnifiedModelsTrainingStep(BaseStep):
                 try:
                     tprint_info("🔍 Calculating disagreement meta-features from base model outputs...")
 
-                    # Initialize disagreement features calculator
-                    disagreement_calc = DisagreementMetaFeatures(logger=self.logger)
+                    # Extract model output columns (predictions, probabilities, confidences)
+                    model_cols = [col for col in base_outputs_for_stats.columns if any(
+                        suffix in col.lower() for suffix in ['_prediction', '_pred', '_prob', '_probability', '_confidence', '_conf']
+                    )]
 
-                    # Prepare model outputs as dict for disagreement calculator
-                    # Assume columns are named like: model1_prediction, model2_prediction, etc.
-                    # or model1_prob_0, model1_prob_1, model2_prob_0, model2_prob_1, etc.
+                    if not model_cols:
+                        tprint_warning("⚠️ No model output columns found, using all columns for disagreement features")
+                        model_cols = list(base_outputs_for_stats.columns)
 
-                    model_predictions = {}
-                    model_probabilities = {}
-                    model_confidences = {}
+                    tprint_info(f"   ↪ Found {len(model_cols)} model output columns")
 
-                    # Parse column names to identify model outputs
-                    for col in base_outputs_for_stats.columns:
-                        col_lower = col.lower()
+                    # Use centralized disagreement feature calculation
+                    meta_features = calculate_ensemble_disagreement_features(
+                        predictions=base_outputs_for_stats[model_cols],
+                        feature_prefix="disagreement",
+                        return_dataframe=True,
+                        index=base_outputs_for_stats.index
+                    )
 
-                        # Extract model predictions (columns ending with _prediction or _pred)
-                        if '_prediction' in col_lower or '_pred' in col_lower:
-                            model_name = col.split('_prediction')[0].split('_pred')[0]
-                            model_predictions[model_name] = base_outputs_for_stats[col].values
+                    # DEBUG: Log disagreement features before adding
+                    tprint_info("=" * 80)
+                    tprint_info("🔍 [DEBUG] DISAGREEMENT FEATURES ANALYSIS")
+                    tprint_info("=" * 80)
+                    tprint_info(f"🔍 [DEBUG] Meta features shape: {meta_features.shape}")
+                    tprint_info(f"🔍 [DEBUG] Meta features columns: {list(meta_features.columns)}")
+                    tprint_info(f"🔍 [DEBUG] Meta features count: {len(meta_features.columns)}")
+                    tprint_info("=" * 80)
 
-                        # Extract model probabilities (columns with _prob or _probability)
-                        elif '_prob' in col_lower or '_probability' in col_lower:
-                            # Group multi-class probabilities by model
-                            parts = col.split('_')
-                            for i, part in enumerate(parts):
-                                if 'prob' in part.lower():
-                                    model_name = '_'.join(parts[:i])
-                                    if model_name not in model_probabilities:
-                                        model_probabilities[model_name] = []
-                                    model_probabilities[model_name].append(base_outputs_for_stats[col].values)
-                                    break
+                    tprint_success(f"✅ Calculated {len(meta_features.columns)} disagreement meta-features:")
+                    tprint_info(f"   Feature columns: {list(meta_features.columns)}")
 
-                        # Extract model confidence scores
-                        elif '_confidence' in col_lower or '_conf' in col_lower:
-                            model_name = col.split('_confidence')[0].split('_conf')[0]
-                            model_confidences[model_name] = base_outputs_for_stats[col].values
-
-                    # Convert probability lists to arrays
-                    for model_name in model_probabilities:
-                        if isinstance(model_probabilities[model_name], list):
-                            model_probabilities[model_name] = np.column_stack(model_probabilities[model_name])
-
-                    tprint_info(f"   ↪ Parsed {len(model_predictions)} prediction outputs")
-                    tprint_info(f"   ↪ Parsed {len(model_probabilities)} probability outputs")
-                    tprint_info(f"   ↪ Parsed {len(model_confidences)} confidence outputs")
-
-                    # Calculate disagreement features
-                    if model_predictions or model_probabilities:
-                        # If we only have predictions, create dummy probabilities
-                        if not model_probabilities and model_predictions:
-                            tprint_warning("⚠️ No probabilities found, using predictions only for disagreement features")
-                            # Convert predictions to simple binary probabilities
-                            for model_name, preds in model_predictions.items():
-                                probs = np.column_stack([
-                                    np.where(preds > 0, 0, 1),  # Prob of class 0 (negative)
-                                    np.where(preds > 0, 1, 0)   # Prob of class 1 (positive)
-                                ])
-                                model_probabilities[model_name] = probs
-
-                        disagreement_features_dict = disagreement_calc.calculate_all_disagreement_features(
-                            model_predictions=model_predictions,
-                            model_probabilities=model_probabilities,
-                            model_confidences=model_confidences if model_confidences else None
-                        )
-
-                        # Convert dict of Series to DataFrame
-                        all_meta_features = pd.DataFrame(disagreement_features_dict, index=base_outputs_for_stats.index)
-
-                        # Filter to keep only the 6 most important disagreement features
-                        # These are the most informative features for ensemble learning
-                        core_features = [
-                            'prediction_dispersion',    # 1. Variance of predictions across models
-                            'confidence_gap',           # 2. Margin between top predictions
-                            'uncertainty',              # 3. Normalized entropy (uncertainty measure)
-                            'prediction_range',         # 4. Range of predictions (max - min)
-                            'avg_divergence',           # 5. Average pairwise model divergence
-                            'max_confidence'            # 6. Highest confidence among models
-                        ]
-
-                        # Select only core features that exist
-                        available_core_features = [f for f in core_features if f in all_meta_features.columns]
-                        meta_features = all_meta_features[available_core_features].copy()
-
-                        # Normalize prediction_range and avg_divergence by standard deviation
-                        features_to_normalize = ['prediction_range', 'avg_divergence']
-                        # DEBUG: Log disagreement features before adding
-                        tprint_info("=" * 80)
-                        tprint_info("🔍 [DEBUG] DISAGREEMENT FEATURES ANALYSIS")
-                        tprint_info("=" * 80)
-                        tprint_info(f"🔍 [DEBUG] Meta features shape: {meta_features.shape}")
-                        tprint_info(f"🔍 [DEBUG] Meta features columns: {list(meta_features.columns)}")
-                        tprint_info(f"🔍 [DEBUG] Meta features count: {len(meta_features.columns)}")
-                        tprint_info("=" * 80)
-                        for feature in features_to_normalize:
-                            if feature in meta_features.columns:
-                                feature_std = meta_features[feature].std()
-                                if feature_std > 0:
-                                    meta_features[feature] = meta_features[feature] / feature_std
-                                    tprint_info(f"   ↪ Normalized '{feature}' by std={feature_std:.6f}")
-                                else:
-                                    tprint_warning(f"   ⚠️ Cannot normalize '{feature}' (std=0)")
-
-                        tprint_success(f"✅ Calculated {len(meta_features.columns)} core disagreement meta-features:")
-                        tprint_info(f"   Feature columns: {list(meta_features.columns)}")
-
-                        if len(available_core_features) < len(core_features):
-                            missing = set(core_features) - set(available_core_features)
-                            tprint_warning(f"   ⚠️ Missing features: {missing}")
-
-                        # Add these new features to the list
+                    # Add these new features to the list
+                    if not meta_features.empty:
                         additional_features_list.append(meta_features)
                     else:
-                        tprint_warning("⚠️ Could not parse model outputs for disagreement features, creating empty meta-features")
-                        meta_features = pd.DataFrame(index=base_outputs_for_stats.index)
+                        tprint_warning("⚠️ Empty disagreement features DataFrame, skipping")
                         # Don't add empty DataFrame to avoid errors
 
                 except Exception as e:
@@ -2730,36 +2652,36 @@ class UnifiedModelsTrainingStep(BaseStep):
         config: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Execute training based on the specified type."""
-            # DEBUG: Log detailed feature information before training
-            tprint_info("=" * 80)
-            tprint_info("🔍 [DEBUG] FEATURE ANALYSIS BEFORE TRAINING")
-            tprint_info("=" * 80)
-            tprint_info(f"🔍 [DEBUG] Training type: {training_type}")
-            tprint_info(f"🔍 [DEBUG] Training data shape: {training_data.shape}")
-            tprint_info(f"🔍 [DEBUG] Training data columns (first 20): {list(training_data.columns[:20])}")
-            tprint_info(f"🔍 [DEBUG] Training data columns (last 20): {list(training_data.columns[-20:])}")
-            tprint_info(f"🔍 [DEBUG] Total feature count: {len(training_data.columns)}")
-            
-            # Count regime features
-            regime_features = [col for col in training_data.columns if 'regime' in col.lower()]
-            tprint_info(f"🔍 [DEBUG] Regime features count: {len(regime_features)}")
-            tprint_info(f"🔍 [DEBUG] Regime features: {regime_features}")
-            
-            # Count disagreement features
-            disagreement_features = [col for col in training_data.columns if any(term in col.lower() for term in ['dispersion', 'disagreement', 'uncertainty', 'confidence_gap', 'prediction_range'])]
-            tprint_info(f"🔍 [DEBUG] Disagreement features count: {len(disagreement_features)}")
-            tprint_info(f"🔍 [DEBUG] Disagreement features: {disagreement_features}")
-            
-            # Count model-specific features
-            model_specific_features = [col for col in training_data.columns if any(term in col.lower() for term in ['catboost', 'lgbm', 'lightgbm', 'depthwise', 'cnn', 'gru'])]
-            tprint_info(f"🔍 [DEBUG] Model-specific features count: {len(model_specific_features)}")
-            tprint_info(f"🔍 [DEBUG] Model-specific features: {model_specific_features}")
-            
-            # Save feature list for comparison during prediction
-            self._training_features = list(training_data.columns)
-            self._training_feature_count = len(training_data.columns)
-            tprint_info(f"🔍 [DEBUG] Saved training feature list ({len(self._training_features)} features) for prediction comparison")
-            tprint_info("=" * 80)
+        # DEBUG: Log detailed feature information before training
+        tprint_info("=" * 80)
+        tprint_info("🔍 [DEBUG] FEATURE ANALYSIS BEFORE TRAINING")
+        tprint_info("=" * 80)
+        tprint_info(f"🔍 [DEBUG] Training type: {training_type}")
+        tprint_info(f"🔍 [DEBUG] Training data shape: {training_data.shape}")
+        tprint_info(f"🔍 [DEBUG] Training data columns (first 20): {list(training_data.columns[:20])}")
+        tprint_info(f"🔍 [DEBUG] Training data columns (last 20): {list(training_data.columns[-20:])}")
+        tprint_info(f"🔍 [DEBUG] Total feature count: {len(training_data.columns)}")
+
+        # Count regime features
+        regime_features = [col for col in training_data.columns if 'regime' in col.lower()]
+        tprint_info(f"🔍 [DEBUG] Regime features count: {len(regime_features)}")
+        tprint_info(f"🔍 [DEBUG] Regime features: {regime_features}")
+
+        # Count disagreement features
+        disagreement_features = [col for col in training_data.columns if any(term in col.lower() for term in ['dispersion', 'disagreement', 'uncertainty', 'confidence_gap', 'prediction_range'])]
+        tprint_info(f"🔍 [DEBUG] Disagreement features count: {len(disagreement_features)}")
+        tprint_info(f"🔍 [DEBUG] Disagreement features: {disagreement_features}")
+
+        # Count model-specific features
+        model_specific_features = [col for col in training_data.columns if any(term in col.lower() for term in ['catboost', 'lgbm', 'lightgbm', 'depthwise', 'cnn', 'gru'])]
+        tprint_info(f"🔍 [DEBUG] Model-specific features count: {len(model_specific_features)}")
+        tprint_info(f"🔍 [DEBUG] Model-specific features: {model_specific_features}")
+
+        # Save feature list for comparison during prediction
+        self._training_features = list(training_data.columns)
+        self._training_feature_count = len(training_data.columns)
+        tprint_info(f"🔍 [DEBUG] Saved training feature list ({len(self._training_features)} features) for prediction comparison")
+        tprint_info("=" * 80)
         try:
             if training_type == 'analyst_base':
                 # Regime probabilities are already added by _get_additional_model_outputs


### PR DESCRIPTION
Consolidated disagreement feature implementations from three ensemble training modules into a single centralized module.

Changes:
- Created src/feature_generation/categories/ensemble_disagreement.py with 6 standardized disagreement features:
  * disagreement_variance - variance across models
  * disagreement_std - standard deviation
  * disagreement_range - max - min range
  * disagreement_mad - mean absolute deviation
  * disagreement_cv - coefficient of variation
  * disagreement_iqr - interquartile range

- Updated analyst_ensemble_training_step.py to use centralized features Removed custom _generate_disagreement_features implementation

- Updated regime_ensemble_training.py to use centralized features Enhanced to calculate features per regime using unified implementation

- Updated unified_models_training_step.py to use centralized features Simplified from complex DisagreementMetaFeatures to standardized set

Benefits:
- Consistency across all ensemble models (analyst, tactician, regime)
- Single source of truth for disagreement feature logic
- Easier maintenance and testing
- Reduced code duplication