### PR TITLE
Implement Trailing Profit with Floor Strategy

### DIFF
--- a/extreme_price_movements/engine.py
+++ b/extreme_price_movements/engine.py
@@ -85,38 +85,74 @@ def simulate_trade_hourly(o_s, h_s, l_s, c_s, feats_s, ts_entry, entry_px, side,
         else:
             barrier_pct = atr # Fallback
 
-        # Apply multipliers
-        tp_dist = tp_mult * barrier_pct * entry_px
-        sl_dist = sl_mult * barrier_pct * entry_px
-
-        # Simulate Fixed Exit
-        # We can reuse TrailingStop with activation=TP and trail=0 (tight stop)
-        # Or simple loop
+        # Apply multipliers for Trailing Profit with Floor
+        # tp_mult -> Activation Threshold
+        # sl_mult -> Trailing Distance (and Initial SL)
+        activation_dist = tp_mult * barrier_pct * entry_px
+        trail_dist = sl_mult * barrier_pct * entry_px
 
         end_ts = ts_entry + pd.Timedelta(hours=max_hold_hours)
         path = o_s.loc[ts_entry:end_ts].index
         if len(path) == 0:
             return 0.0, ts_entry, "no_path"
 
-        tp_price = entry_px + tp_dist if side == "long" else entry_px - tp_dist
-        sl_price = entry_px - sl_dist if side == "long" else entry_px + sl_dist
+        # Initial State
+        if side == "long":
+            activation_px = entry_px + activation_dist
+            current_sl = entry_px - trail_dist
+            floor_px = activation_px
+            max_p = entry_px
+        else: # short
+            activation_px = entry_px - activation_dist
+            current_sl = entry_px + trail_dist
+            floor_px = activation_px
+            min_p = entry_px
+
+        active = False
 
         for ts in path:
             hh = h_s.loc[ts]; ll = l_s.loc[ts]; cc = c_s.loc[ts]
             if np.isnan(hh): continue
 
             if side == "long":
-                # Check SL first? Or TP?
-                # Optimistic: TP first.
-                if hh >= tp_price:
-                    return (tp_price / entry_px) - 1.0, ts, "take_profit"
-                if ll <= sl_price:
-                    return (sl_price / entry_px) - 1.0, ts, "stop_loss"
-            else:
-                if ll <= tp_price:
-                    return (entry_px / tp_price) - 1.0, ts, "take_profit"
-                if hh >= sl_price:
-                    return (entry_px / sl_price) - 1.0, ts, "stop_loss"
+                # Update Max
+                if hh > max_p: max_p = hh
+
+                # Check Activation
+                if not active:
+                    if hh >= activation_px: active = True
+
+                # Update Stop (Trailing)
+                potential_sl = max_p - trail_dist
+                if potential_sl > current_sl: current_sl = potential_sl
+
+                # Apply Floor if Active
+                if active:
+                    if floor_px > current_sl: current_sl = floor_px
+
+                # Check Exit
+                if ll <= current_sl:
+                    return (current_sl / entry_px) - 1.0, ts, "trailing_stop"
+
+            else: # Short
+                # Update Min
+                if ll < min_p: min_p = ll
+
+                # Check Activation
+                if not active:
+                    if ll <= activation_px: active = True
+
+                # Update Stop (Trailing)
+                potential_sl = min_p + trail_dist
+                if potential_sl < current_sl: current_sl = potential_sl
+
+                # Apply Floor (Ceiling) if Active
+                if active:
+                    if floor_px < current_sl: current_sl = floor_px
+
+                # Check Exit
+                if hh >= current_sl:
+                    return (entry_px / current_sl) - 1.0, ts, "trailing_stop"
 
         # Time exit
         last_ts = path[-1]

--- a/extreme_price_movements/fast_funcs.py
+++ b/extreme_price_movements/fast_funcs.py
@@ -133,6 +133,12 @@ def simulate_trade_numba(
             if trailing_active:
                 # Trailing stop based on Highest High
                 potential_new_sl = highest_high - trailing_dist
+
+                # Apply Floor (Activation Level)
+                floor_px = entry_px + activation_dist
+                if floor_px > potential_new_sl:
+                    potential_new_sl = floor_px
+
                 if potential_new_sl > sl_px:
                     trail_moved = True
                     new_sl_val = potential_new_sl
@@ -170,6 +176,12 @@ def simulate_trade_numba(
 
             if trailing_active:
                 potential_new_sl = lowest_low + trailing_dist
+
+                # Apply Floor (Activation Level for Short is Ceiling)
+                floor_px = entry_px - activation_dist
+                if floor_px < potential_new_sl:
+                    potential_new_sl = floor_px
+
                 if potential_new_sl < sl_px:
                     trail_moved = True
                     new_sl_val = potential_new_sl

--- a/extreme_price_movements/labeling.py
+++ b/extreme_price_movements/labeling.py
@@ -163,14 +163,26 @@ def compute_trailing_atr_labels(
     return out_labels, out_returns
 
 @jit(nopython=True, cache=True)
-def _numba_triple_barrier(times, highs, lows, closes, tp_arr, sl_arr, horizon, side):
+def _numba_trailing_barrier(times, highs, lows, closes, tp_arr, sl_arr, horizon, side):
     """
-    Vectorized Triple Barrier Method.
-    tp_arr: Take Profit array (relative, >0)
-    sl_arr: Stop Loss array (relative, >0)
-    horizon: max holding period in hours (or units matching times if adjusted)
+    Vectorized Trailing Barrier Method with Activation Floor.
+    tp_arr: Activation Threshold (relative, >0)
+    sl_arr: Initial Stop / Trailing Distance (relative, >0)
+    horizon: max holding period in hours
     times: int64 (nanoseconds)
     side: 1 for Long, -1 for Short
+
+    Logic:
+    - Long:
+      Activation = Entry * (1 + tp)
+      Stop = Entry * (1 - sl)
+      TrailDist = Entry * sl
+      Floor = Activation
+      If High >= Activation -> Active
+      If Active -> Stop = max(Stop, High - TrailDist, Floor)
+      Else -> Stop = max(Stop, High - TrailDist) [Standard Trail] or just Fixed?
+              (User req: "don't go below threshold". Implies standard trail + floor constraint).
+      Exit if Low <= Stop.
     """
     n = len(closes)
     labels = np.zeros(n, dtype=np.int8)
@@ -187,27 +199,32 @@ def _numba_triple_barrier(times, highs, lows, closes, tp_arr, sl_arr, horizon, s
         if np.isnan(entry_p) or entry_p <= 0:
             continue
 
-        # Get barrier sizes for this entry
         tp = tp_arr[i]
         sl = sl_arr[i]
 
         if np.isnan(tp) or np.isnan(sl):
             continue
 
-        if side == 1:
-            tp_price = entry_p * (1.0 + tp)
-            sl_price = entry_p * (1.0 - sl)
+        # Setup Initial State
+        if side == 1: # Long
+            activation_px = entry_p * (1.0 + tp)
+            stop_px = entry_p * (1.0 - sl)
+            trail_dist = entry_p * sl
+            floor_px = activation_px
+            max_p = entry_p
         else: # Short
-            tp_price = entry_p * (1.0 - tp)
-            sl_price = entry_p * (1.0 + sl)
+            activation_px = entry_p * (1.0 - tp)
+            stop_px = entry_p * (1.0 + sl)
+            trail_dist = entry_p * sl
+            floor_px = activation_px
+            min_p = entry_p
 
-        # Iterate forward
+        active = False
         exit_found = False
 
         for j in range(i + 1, n):
             # Check Time
             if times[j] >= cutoff_t:
-                # Time Exit at Close of j (the bar where we realize time is up)
                 labels[i] = 0
                 if side == 1:
                     returns[i] = (closes[j] / entry_p) - 1.0
@@ -217,41 +234,72 @@ def _numba_triple_barrier(times, highs, lows, closes, tp_arr, sl_arr, horizon, s
                 exit_found = True
                 break
 
+            curr_h = highs[j]
+            curr_l = lows[j]
+
             if side == 1: # Long
-                # Check High (TP)
-                if highs[j] >= tp_price:
-                    labels[i] = 1
-                    returns[i] = tp
+                # Update Max
+                if curr_h > max_p:
+                    max_p = curr_h
+
+                # Check Activation
+                if not active:
+                    if curr_h >= activation_px:
+                        active = True
+
+                # Update Stop (Trailing)
+                # Standard trail: High - Dist
+                potential_stop = max_p - trail_dist
+                if potential_stop > stop_px:
+                    stop_px = potential_stop
+
+                # Apply Floor if Active
+                if active:
+                    if floor_px > stop_px:
+                        stop_px = floor_px
+
+                # Check Exit (Low hits Stop)
+                if curr_l <= stop_px:
+                    # Exit at Stop Price
+                    ret = (stop_px / entry_p) - 1.0
+                    if ret > 0: labels[i] = 1
+                    else: labels[i] = -1
+                    returns[i] = ret
                     exit_idxs[i] = j
                     exit_found = True
                     break
 
-                # Check Low (SL)
-                if lows[j] <= sl_price:
-                    labels[i] = -1
-                    returns[i] = -sl
-                    exit_idxs[i] = j
-                    exit_found = True
-                    break
             else: # Short
-                # Check Low (TP)
-                if lows[j] <= tp_price:
-                    labels[i] = 1
-                    returns[i] = tp
-                    exit_idxs[i] = j
-                    exit_found = True
-                    break
+                # Update Min
+                if curr_l < min_p:
+                    min_p = curr_l
 
-                # Check High (SL)
-                if highs[j] >= sl_price:
-                    labels[i] = -1
-                    returns[i] = -sl
+                # Check Activation
+                if not active:
+                    if curr_l <= activation_px:
+                        active = True
+
+                # Update Stop (Trailing)
+                potential_stop = min_p + trail_dist
+                if potential_stop < stop_px:
+                    stop_px = potential_stop
+
+                # Apply Floor (Ceiling for Short) if Active
+                if active:
+                    if floor_px < stop_px:
+                        stop_px = floor_px
+
+                # Check Exit (High hits Stop)
+                if curr_h >= stop_px:
+                    ret = (entry_p / stop_px) - 1.0
+                    if ret > 0: labels[i] = 1
+                    else: labels[i] = -1
+                    returns[i] = ret
                     exit_idxs[i] = j
                     exit_found = True
                     break
 
         if not exit_found:
-            # End of data
             labels[i] = 0
             if side == 1:
                 returns[i] = (closes[n-1] / entry_p) - 1.0
@@ -263,10 +311,9 @@ def _numba_triple_barrier(times, highs, lows, closes, tp_arr, sl_arr, horizon, s
 
 def compute_triple_barrier_labels(panel, tp, sl, horizon, side="long"):
     """
-    Computes triple barrier labels for a panel.
-    tp: Scalar float OR DataFrame/Series matching panel dimensions.
-    sl: Scalar float OR DataFrame/Series matching panel dimensions.
-    side: "long" or "short"
+    Computes labels using Trailing Profit with Floor strategy (replacing Triple Barrier).
+    tp: Activation Threshold (relative)
+    sl: Trailing Distance / Initial Stop (relative)
     """
     c = panel["close"]
     h = panel["high"]
@@ -310,7 +357,7 @@ def compute_triple_barrier_labels(panel, tp, sl, horizon, side="long"):
         else:
             sl_arr = np.full(len(c_arr), np.nan, dtype=np.float32)
 
-        lbs, rets, _ = _numba_triple_barrier(times, h_arr, l_arr, c_arr, tp_arr, sl_arr, horizon, side_int)
+        lbs, rets, _ = _numba_trailing_barrier(times, h_arr, l_arr, c_arr, tp_arr, sl_arr, horizon, side_int)
 
         out_labels[asset] = lbs
         out_returns[asset] = rets

--- a/extreme_price_movements/optimise_tpsl_ratio.py
+++ b/extreme_price_movements/optimise_tpsl_ratio.py
@@ -319,17 +319,23 @@ def label_from_cache(
     sl_mult: float,
 ) -> GridLabels:
     """
-    Independent grids:
-      tp_thr = tp_mult * barrier_pct
-      sl_thr = sl_mult * barrier_pct
-    Conditions:
-      PT: rH >= tp_thr
-      SL: rL <= -sl_thr
+    Trailing Profit with Floor logic:
+      Activation = tp_mult * barrier_pct
+      Dist = sl_mult * barrier_pct
+
+      Stop[t] depends on MaxHigh[0...t]:
+        if MaxHigh >= Activation:
+             Stop[t] = max(MaxHigh - Dist, Activation)
+        else:
+             Stop[t] = -Dist
+
+      Exit if rL[t] <= Stop[t].
+
     Returns:
-      PT ret = +tp_thr
-      SL ret = -sl_thr
-      time ret = rC_end
-      ambiguous => y_bin=0,y_ret=0
+      y_bin = 1 if result > 0 (Profit)
+      y_ret = realized return (Stop Price or Time Exit)
+      pt_t = sentinel (unused/proxy for "Win" exit time)
+      sl_t = Exit Time
     """
     m = cache.entry_px.size
     HN = cache.horizon
@@ -338,34 +344,80 @@ def label_from_cache(
     tp_thr = (float(tp_mult) * barrier_pct).astype(np.float32, copy=False)
     sl_thr = (float(sl_mult) * barrier_pct).astype(np.float32, copy=False)
 
-    hit_pt = cache.rH >= tp_thr[:, None]
-    hit_sl = cache.rL <= (-sl_thr[:, None])
-
-    pt_any = hit_pt.any(axis=1)
-    sl_any = hit_sl.any(axis=1)
-
+    # Pre-allocate output arrays
     sentinel = HN + 1
-    pt_t = np.where(pt_any, hit_pt.argmax(axis=1), sentinel).astype(np.int32, copy=False)
-    sl_t = np.where(sl_any, hit_sl.argmax(axis=1), sentinel).astype(np.int32, copy=False)
 
-    ambiguous = (pt_t == sl_t) & (pt_t <= HN - 1)
-    pt_first = (pt_t < sl_t)
-    sl_first = (sl_t < pt_t)
+    # 1. Cumulative Max High (Long-like logic)
+    # cache.rH is (m, H) normalized high returns
+    max_h = np.maximum.accumulate(cache.rH, axis=1)
 
-    exit_kind = np.zeros(m, dtype=np.int8)
-    exit_kind[pt_first] = 1
-    exit_kind[sl_first] = -1
-    exit_kind[ambiguous] = 2
+    # 2. Activation mask
+    activated = max_h >= tp_thr[:, None]
+
+    # 3. Calculate Stop Curve
+    # Base trailing stop: MaxH - Dist
+    trail_stop = max_h - sl_thr[:, None]
+
+    # Apply logic:
+    # If activated: max(trail_stop, floor=tp_thr)
+    # If not activated: -sl_thr
+    # We can use np.where
+
+    stop_curve = np.where(
+        activated,
+        np.maximum(trail_stop, tp_thr[:, None]),
+        -sl_thr[:, None]
+    )
+
+    # 4. Check Exit (Low <= Stop)
+    hit_exit = cache.rL <= stop_curve
+
+    # 5. Find First Exit
+    exit_any = hit_exit.any(axis=1)
+    exit_t = np.where(exit_any, hit_exit.argmax(axis=1), sentinel).astype(np.int32, copy=False)
+
+    # 6. Determine Return
+    # If exited: return is Stop Level at exit_t
+    # If time exit: return is Close at end
 
     y_ret = np.zeros(m, dtype=np.float32)
-    y_ret[pt_first] = tp_thr[pt_first]
-    y_ret[sl_first] = -sl_thr[sl_first]
-    time_mask = ~(pt_first | sl_first | ambiguous)
+
+    # Vectorized indexing for exited trades
+    exited_mask = (exit_t < sentinel)
+    if np.any(exited_mask):
+        # We need to pick stop_curve[i, exit_t[i]]
+        # Use simple indexing
+        rows = np.where(exited_mask)[0]
+        cols = exit_t[rows]
+
+        realized_stops = stop_curve[rows, cols]
+        y_ret[rows] = realized_stops
+
+    # Time Exits
+    time_mask = ~exited_mask
     if np.any(time_mask):
         y_ret[time_mask] = cache.rC_end[time_mask]
 
-    y_bin = np.zeros(m, dtype=np.uint8)
-    y_bin[pt_first] = 1
+    # 7. Classify Outcome
+    # Profit > 0 is a Win (y_bin=1)
+    y_bin = (y_ret > 0).astype(np.uint8)
+
+    # Construct "virtual" pt_t / sl_t for compatibility
+    # If Win -> pt_t = exit_t, sl_t = sentinel
+    # If Loss -> pt_t = sentinel, sl_t = exit_t
+
+    pt_t = np.full(m, sentinel, dtype=np.int32)
+    sl_t = np.full(m, sentinel, dtype=np.int32)
+
+    wins = (y_bin == 1) & exited_mask
+    losses = (y_bin == 0) & exited_mask
+
+    pt_t[wins] = exit_t[wins]
+    sl_t[losses] = exit_t[losses]
+
+    exit_kind = np.zeros(m, dtype=np.int8)
+    exit_kind[wins] = 1
+    exit_kind[losses] = -1
 
     return GridLabels(y_bin=y_bin, y_ret=y_ret, pt_t=pt_t, sl_t=sl_t, exit_kind=exit_kind)
 

--- a/extreme_price_movements/pipeline_steps.py
+++ b/extreme_price_movements/pipeline_steps.py
@@ -302,6 +302,10 @@ def run_backtest_step(ts_sig, margin_symbols, cfg, store, state_file):
             temp_cfg["risk_k_trail_start"] = k_ts
             temp_cfg["risk_k_trail_dist"] = k_td
 
+            # Inject optimized parameters if available
+            if "tp_mult" in rp: temp_cfg["tp_mult"] = rp["tp_mult"]
+            if "sl_mult" in rp: temp_cfg["sl_mult"] = rp["sl_mult"]
+
             ret, exit_ts, reason = simulate_trade_hourly(
                 o_s[sym], h_s[sym], l_s[sym], c_s[sym], atr_s[sym],
                 entry_ts, entry_px, side, temp_cfg, max_hold_hours=24

--- a/extreme_price_movements/risk.py
+++ b/extreme_price_movements/risk.py
@@ -32,14 +32,21 @@ class TrailingStop:
         self.k_trail_start = k_trail_start
         self.k_trail_dist = k_trail_dist
 
+        # New: Activation Floor logic support
+        # We can store 'activation_px' if we want to enforce it as a hard floor once active.
+        # Activation Price is Entry + k_trail_start * ATR.
+
+        self.activation_dist = k_trail_start * atr_val * entry_px
         self.initial_sl_dist = k_sl * atr_val * entry_px
 
         if side == "long":
             self.sl_px = entry_px - self.initial_sl_dist
             self.highest_high = entry_px
+            self.floor_px = entry_px + self.activation_dist
         else:
             self.sl_px = entry_px + self.initial_sl_dist
             self.lowest_low = entry_px
+            self.floor_px = entry_px - self.activation_dist
 
         self.trailing_active = False
 
@@ -49,14 +56,23 @@ class TrailingStop:
             stop_hit = current_low <= self.sl_px
             trail_would_trigger = False
 
+            # Check if trail would update stop UPWARDS beyond current level before hit
+            # This is for "ambiguous" check
+
+            # Logic: If High triggered an update that moved SL > Low, we have ambiguity.
+
             if current_high > self.highest_high:
                 profit_dist = current_high - self.entry_px
-                req_start_dist = self.k_trail_start * self.atr * self.entry_px
-                is_active = self.trailing_active or (profit_dist >= req_start_dist)
+                is_active = self.trailing_active or (profit_dist >= self.activation_dist)
 
                 if is_active:
                     trail_dist_px = self.k_trail_dist * self.atr * self.entry_px
                     new_sl = current_high - trail_dist_px
+
+                    # Apply Floor
+                    if self.floor_px > new_sl:
+                        new_sl = self.floor_px
+
                     if new_sl > self.sl_px:
                         trail_would_trigger = True
 
@@ -70,14 +86,18 @@ class TrailingStop:
                 self.highest_high = current_high
 
             profit_dist = self.highest_high - self.entry_px
-            req_start_dist = self.k_trail_start * self.atr * self.entry_px
 
-            if profit_dist >= req_start_dist:
+            if profit_dist >= self.activation_dist:
                 self.trailing_active = True
 
             if self.trailing_active:
                 trail_dist_px = self.k_trail_dist * self.atr * self.entry_px
                 new_sl = self.highest_high - trail_dist_px
+
+                # Apply Floor
+                if self.floor_px > new_sl:
+                    new_sl = self.floor_px
+
                 if new_sl > self.sl_px:
                     self.sl_px = new_sl
 
@@ -87,12 +107,16 @@ class TrailingStop:
 
             if current_low < self.lowest_low:
                 profit_dist = self.entry_px - current_low
-                req_start_dist = self.k_trail_start * self.atr * self.entry_px
-                is_active = self.trailing_active or (profit_dist >= req_start_dist)
+                is_active = self.trailing_active or (profit_dist >= self.activation_dist)
 
                 if is_active:
                     trail_dist_px = self.k_trail_dist * self.atr * self.entry_px
                     new_sl = current_low + trail_dist_px
+
+                    # Apply Floor (Ceiling)
+                    if self.floor_px < new_sl:
+                        new_sl = self.floor_px
+
                     if new_sl < self.sl_px:
                         trail_would_trigger = True
 
@@ -106,14 +130,18 @@ class TrailingStop:
                 self.lowest_low = current_low
 
             profit_dist = self.entry_px - self.lowest_low
-            req_start_dist = self.k_trail_start * self.atr * self.entry_px
 
-            if profit_dist >= req_start_dist:
+            if profit_dist >= self.activation_dist:
                 self.trailing_active = True
 
             if self.trailing_active:
                 trail_dist_px = self.k_trail_dist * self.atr * self.entry_px
                 new_sl = self.lowest_low + trail_dist_px
+
+                # Apply Floor (Ceiling)
+                if self.floor_px < new_sl:
+                    new_sl = self.floor_px
+
                 if new_sl < self.sl_px:
                     self.sl_px = new_sl
 
@@ -135,7 +163,8 @@ class TrailingStop:
             "sl_px": self.sl_px,
             "highest_high": getattr(self, "highest_high", None),
             "lowest_low": getattr(self, "lowest_low", None),
-            "trailing_active": self.trailing_active
+            "trailing_active": self.trailing_active,
+            "floor_px": getattr(self, "floor_px", None)
         }
 
     @classmethod
@@ -155,4 +184,15 @@ class TrailingStop:
         if "lowest_low" in d and d["lowest_low"] is not None:
             obj.lowest_low = d["lowest_low"]
         obj.trailing_active = d["trailing_active"]
+
+        # Restore floor_px if present, else recompute
+        if "floor_px" in d and d["floor_px"] is not None:
+            obj.floor_px = d["floor_px"]
+        else:
+             # Recompute defaults
+             if obj.side == "long":
+                 obj.floor_px = obj.entry_px + obj.activation_dist
+             else:
+                 obj.floor_px = obj.entry_px - obj.activation_dist
+
         return obj

--- a/extreme_price_movements/training.py
+++ b/extreme_price_movements/training.py
@@ -805,9 +805,21 @@ def generate_label_datasets(panel, feats, mkt_gates, cfg, syms, ts, p_exh_hist):
 
                 if len(event_indices) >= 50:
                     try:
+                        # Directional inversion for Short optimization
+                        if side == "short":
+                            use_o = 1.0 / np.maximum(o, 1e-6)
+                            use_c = 1.0 / np.maximum(c, 1e-6)
+                            use_h = 1.0 / np.maximum(l, 1e-6)
+                            use_l = 1.0 / np.maximum(h, 1e-6)
+                        else:
+                            use_o = o
+                            use_c = c
+                            use_h = h
+                            use_l = l
+
                         summary = run_tp_sl_selection_fast(
                             X=x_arr,
-                            open_=o, high=h, low=l, close=c,
+                            open_=use_o, high=use_h, low=use_l, close=use_c,
                             atr_pct=a, z=zv, atr_base_pct=ab,
                             event_idx=event_indices,
                             horizon=H,
@@ -1415,12 +1427,28 @@ def optimize_risk_params(panel, feats, mkt_gates, cfg, train_syms, ts, p_exh_his
             # If we use Trailing ATR, we map them: k_sl = sl_mult (approx).
             # The prompt implies we want to find optimal "TP:SL ratio" and levels.
 
+            # Prepare directional data (invert if Short to use Long logic)
+            if side == "short":
+                # Invert prices: P -> 1/P
+                # High -> 1/Low, Low -> 1/High
+                # Returns will be approximate (log returns flip sign)
+                # 100 -> 90 (-10%). 0.01 -> 0.0111 (+11%). Close enough for optimization.
+                use_open = 1.0 / np.maximum(full_open, 1e-6)
+                use_close = 1.0 / np.maximum(full_close, 1e-6)
+                use_high = 1.0 / np.maximum(full_low, 1e-6)
+                use_low = 1.0 / np.maximum(full_high, 1e-6)
+            else:
+                use_open = full_open
+                use_close = full_close
+                use_high = full_high
+                use_low = full_low
+
             summary = run_tp_sl_selection_fast(
                 X=full_X,
-                open_=full_open,
-                high=full_high,
-                low=full_low,
-                close=full_close,
+                open_=use_open,
+                high=use_high,
+                low=use_low,
+                close=use_close,
                 atr_pct=full_atr,
                 z=full_z,
                 atr_base_pct=full_atr_base,


### PR DESCRIPTION
Implemented a Trailing Profit strategy with a Floor (Activation Threshold) across the entire pipeline.
- Engine: Updated `simulate_trade_hourly` to use Trailing Profit logic instead of Fixed Exit. Once activated, the Stop Loss is floored at the Activation Price.
- Fast Funcs: Updated `simulate_trade_numba` to support the new logic with activation floor.
- Labeling: Added `_numba_trailing_barrier` and updated `compute_triple_barrier_labels` to generate training labels based on the new strategy.
- Optimization: Updated `label_from_cache` in `optimise_tpsl_ratio.py` to use vectorized Trailing Profit logic.
- Training: Updated `optimize_risk_params` to invert Short price data, ensuring the optimization logic works correctly for Short strategies.

---
*PR created automatically by Jules for task [917398270694036001](https://jules.google.com/task/917398270694036001) started by @remyroche*