### PR TITLE
Fix meta model NaNs and Inversion

### DIFF
--- a/extreme_price_movements/meta_model.py
+++ b/extreme_price_movements/meta_model.py
@@ -382,8 +382,14 @@ class MetaModel:
 
     def _signed_log_demeaned(self, y: np.ndarray) -> np.ndarray:
         y = np.asarray(y, dtype=float)
-        z = np.sign(y) * np.log1p(np.abs(y))
-        return z - float(np.mean(z))
+        valid = np.isfinite(y)
+        if not valid.any():
+            return np.zeros_like(y)
+        z = np.zeros_like(y)
+        z[valid] = np.sign(y[valid]) * np.log1p(np.abs(y[valid]))
+        mu = np.mean(z[valid])
+        z[valid] -= mu
+        return z
 
     def _select_features_for_candidate(self, X: pd.DataFrame, y: np.ndarray, candidate_name: str, kind: str) -> List[str]:
         # Independent feature selection per candidate as requested.
@@ -681,6 +687,15 @@ class MetaModel:
             pnl_std = float(np.std(chunk_vals)) if chunk_vals else 0.0
             sortino = float(_sortino_numba(yk.astype(np.float64)))
             maxdd = float(_maxdd_numba(yk.astype(np.float64)))
+
+            yk_clean = yk[np.isfinite(yk)]
+            if len(yk_clean) > 0:
+                mono_69 = float(np.mean(np.diff(np.quantile(yk_clean, np.linspace(0.6, 0.9, 4))) >= -1e-12))
+                mono_79 = float(np.mean(np.diff(np.quantile(yk_clean, np.linspace(0.7, 0.9, 3))) >= -1e-12))
+                mono_89 = float(np.mean(np.diff(np.quantile(yk_clean, np.linspace(0.8, 0.9, 3))) >= -1e-12))
+            else:
+                mono_69, mono_79, mono_89 = 0.0, 0.0, 0.0
+
             rows.append({
                 "k": k,
                 "precision@topk": prec,
@@ -696,9 +711,9 @@ class MetaModel:
                 "coverage_topdec_tau085_raw": float(np.mean(yk <= pred[idx])),
                 "coverage_global_tau085_cal": float(np.mean(y <= pred)),
                 "coverage_topdec_tau085_cal": float(np.mean(yk <= pred[idx])),
-                "monotonicity_0.6_0.9": float(np.mean(np.diff(np.quantile(yk, np.linspace(0.6, 0.9, 4))) >= -1e-12)),
-                "monotonicity_0.7_0.9": float(np.mean(np.diff(np.quantile(yk, np.linspace(0.7, 0.9, 3))) >= -1e-12)),
-                "monotonicity_0.8_0.9": float(np.mean(np.diff(np.quantile(yk, np.linspace(0.8, 0.9, 3))) >= -1e-12)),
+                "monotonicity_0.6_0.9": mono_69,
+                "monotonicity_0.7_0.9": mono_79,
+                "monotonicity_0.8_0.9": mono_89,
             })
         metric_df = pd.DataFrame(rows)
 

--- a/extreme_price_movements/training.py
+++ b/extreme_price_movements/training.py
@@ -415,8 +415,15 @@ class AlphaHorizonEnsemble:
 def compute_meta_target(ret2: np.ndarray, ret4: np.ndarray, ret8: np.ndarray) -> np.ndarray:
     def _signed_log_demeaned(x):
         x = np.asarray(x, dtype=float)
-        z = np.sign(x) * np.log1p(np.abs(x))
-        return z - float(np.mean(z))
+        valid = np.isfinite(x)
+        if not valid.any():
+            return np.zeros_like(x)
+        z = np.zeros_like(x)
+        z[valid] = np.sign(x[valid]) * np.log1p(np.abs(x[valid]))
+        # Use only valid values for centering
+        mu = np.mean(z[valid])
+        z[valid] -= mu
+        return z
 
     r2 = _signed_log_demeaned(ret2)
     r4 = _signed_log_demeaned(ret4)
@@ -1954,6 +1961,20 @@ def train_meta_models_from_artifacts(datasets, cfg, alpha_models):
                 return y_ret.astype(np.float32)
 
             y_target = compute_meta_target(_ret_for_h_aligned(2), _ret_for_h_aligned(4), _ret_for_h_aligned(8))
+
+            # Diagnostic: check y_target integrity
+            n_nan_y = np.isnan(y_target).sum()
+            n_tot = len(y_target)
+            if n_nan_y > 0:
+                tprint(f"  WARNING: y_target has {n_nan_y}/{n_tot} NaNs! Replacing with 0.")
+                y_target = np.nan_to_num(y_target, nan=0.0)
+
+            # Diagnostic: check y_target correlation with y_ret (should be positive)
+            if np.std(y_target) > 1e-9 and np.std(y_ret) > 1e-9:
+                corr_tgt = np.corrcoef(y_target, y_ret)[0, 1]
+                tprint(f"  Meta Target Check: Corr(y_target, y_ret) = {corr_tgt:.4f}")
+                if corr_tgt < 0.2:
+                    tprint(f"  WARNING: Low/Negative correlation between meta target and raw returns ({corr_tgt:.4f})!")
 
             n_res = df.get("__n_res__", pd.Series(np.ones(len(df)), index=df.index)).values.astype(np.float32)
             keep = n_res >= np.quantile(n_res, 0.20)


### PR DESCRIPTION
This PR addresses the critical regression in meta models (negative IC, poor coverage, monotonicity 0.00) identified in the recent report.

Root Cause:
The `_signed_log_demeaned` function used `np.mean` without handling NaNs. If the input dataset (returns) contained even a single NaN (e.g., from missing horizon data), the centering operation propagated NaNs to the entire target array `y_target`.
- This caused `Monotonicity` metric to return 0.00 (as `np.quantile` on NaNs fails).
- It corrupted the training target `y_fit`, leading to garbage models (negative IC, inverted logic) because the regressor likely learned from a degenerate or zero-filled fallback state (depending on internal handling).

Fixes:
1.  **Robust Target Calculation:** Modified `_signed_log_demeaned` in both `meta_model.py` and `training.py` (inside `compute_meta_target`) to use explicit validity masks (`np.isfinite`). It now computes the mean only on valid values and fills NaNs with 0 (neutral target) in the output. This ensures `y_target` is always clean and finite.
2.  **Robust Metric Calculation:** Updated `_write_model_reports` in `meta_model.py` to filter out non-finite values from `yk` before calculating the Monotonicity metric. This prevents the metric from falsely reporting 0.00 due to edge-case NaNs in OOF predictions or targets.
3.  **Diagnostics:** Added logging in `training.py` to report the number of NaNs in `y_target` and its correlation with raw returns `y_ret`. This provides immediate visibility if data integrity issues recur or if the target-return relationship is inverted.

Verification:
- Validated that `_signed_log_demeaned` now correctly handles arrays with NaNs (outputting 0 for NaN positions and correctly centering the rest).
- Validated that `compute_meta_target` produces clean outputs from inputs with partial NaNs.
- Verified syntax and structure of modified files.


---
*PR created automatically by Jules for task [378907745708515434](https://jules.google.com/task/378907745708515434) started by @remyroche*