### PR TITLE
Fix base model metrics regression by restoring TP-vs-Rest training

### DIFF
--- a/extreme_price_movements/config.py
+++ b/extreme_price_movements/config.py
@@ -233,7 +233,7 @@ CFG = {
     "label_min_tp_hit_rate": 0.02,
     "label_max_timeout_rate": 0.90,
     # Base label handling: exclude timeout (TO) from TP-vs-SL base classifier targets
-    "base_exclude_timeout_from_classifier": True,
+    "base_exclude_timeout_from_classifier": False,
 
     # ATR normalization for barrier scaling
     "atr_norm_fast_hl_hours": 24,


### PR DESCRIPTION
Reverted `base_exclude_timeout_from_classifier` to `False` in `extreme_price_movements/config.py`. 

**Reasoning:**
The user reported a regression: "lower Lift_k, lower ROC_AUC, worse Brier score, but higher PR_AUC". This specific profile is characteristic of training on a balanced subset (TP vs SL) and evaluating on an imbalanced full set (TP vs SL vs Timeout).
*   **TP vs SL (Exclude Timeouts):** High prevalence (~50%) leads to high baseline Precision (and thus high PR_AUC), but the model never learns to distinguish signal (TP) from noise (Timeouts). When applied to the real world (where Timeouts are 90%+ of cases), it generates many False Positives, ruining Lift and ROC_AUC.
*   **TP vs Rest (Include Timeouts):** Low prevalence (~5%) leads to lower PR_AUC (harder task), but the model explicitly learns to filter out noise. This results in superior ranking (High Lift), better discrimination (High ROC_AUC), and accurate probability calibration (Good Brier).

This change restores the "TP vs Rest" behavior.

---
*PR created automatically by Jules for task [7280682066529952447](https://jules.google.com/task/7280682066529952447) started by @remyroche*