### PR TITLE
Fix memory efficiency & side-effects on parquet reads

### DIFF
--- a/extreme_price_movements/offline_optimisers/compare_candidate_thresholds.py
+++ b/extreme_price_movements/offline_optimisers/compare_candidate_thresholds.py
@@ -203,7 +203,7 @@ def _load_or_download_15m(symbol: str, start_ts: pd.Timestamp, end_ts: pd.Timest
             idx = pd.to_datetime(df.index)
             df.index = idx.tz_localize("UTC") if idx.tz is None else idx.tz_convert("UTC")
             out = df.loc[(df.index >= start_ts) & (df.index <= end_ts), ["open", "high", "low", "close"]]
-            return out.astype(np.float32, copy=False)
+            return out.astype(np.float32, copy=True)
         except Exception:
             pass
     if not allow_download:

--- a/extreme_price_movements/offline_optimisers/compare_tbm_parameters.py
+++ b/extreme_price_movements/offline_optimisers/compare_tbm_parameters.py
@@ -233,7 +233,7 @@ def _load_or_download_15m(symbol: str, start_ts: pd.Timestamp, end_ts: pd.Timest
     if clean in cache:
         df = cache[clean]
         if df.empty: return df
-        return df.loc[(df.index >= start_ts) & (df.index <= end_ts), ["open", "high", "low", "close"]].astype(np.float32, copy=False)
+        return df.loc[(df.index >= start_ts) & (df.index <= end_ts), ["open", "high", "low", "close"]].astype(np.float32, copy=True)
 
     # 2. Check Disk
     path = HF_DATA_DIR / f"{clean}_15m.parquet"

--- a/extreme_price_movements/ridge_position_sizer.py
+++ b/extreme_price_movements/ridge_position_sizer.py
@@ -228,7 +228,7 @@ def simulate_trade_exit_batch(
     n_trades = len(entry_prices)
     exit_prices = np.empty(n_trades, dtype=np.float64)
     exit_bars = np.empty(n_trades, dtype=np.int64)
-    exit_reasons = np.empty(n_trades, dtype=np.int64)
+    exit_reasons = np.empty(n_trades, dtype=np.int8)
     
     for i in prange(n_trades):
         exit_prices[i], exit_bars[i], exit_reasons[i] = simulate_trade_exit(
@@ -729,7 +729,7 @@ def compute_policy_aware_labels_batch(
 
     # Pre-allocate dense blocks once to avoid list append + np.array conversion.
     entry_prices_arr = np.empty(n_candidates, dtype=np.float64)
-    is_longs_arr = np.empty(n_candidates, dtype=np.int64)
+    is_longs_arr = np.empty(n_candidates, dtype=np.int8)
     tp_prices_arr = np.empty(n_candidates, dtype=np.float64)
     sl_prices_arr = np.empty(n_candidates, dtype=np.float64)
     trailing_pcts_arr = np.full(n_candidates, float(trailing_pct), dtype=np.float64)


### PR DESCRIPTION
Implement the suggested memory optimization techniques across the pipeline, ensuring arrays take less memory by casting to `np.int8` where possible (such as in the exit reasons) and applying strict copying to `pd.read_parquet` slices.

---
*PR created automatically by Jules for task [736868645576394422](https://jules.google.com/task/736868645576394422) started by @remyroche*