### PR TITLE
Fix Layer 0 mask optimizer bias against Mean Reversion regimes

### DIFF
--- a/extreme_price_movements/mask_optimiser.py
+++ b/extreme_price_movements/mask_optimiser.py
@@ -571,10 +571,15 @@ def _compute_conditional_learnability(
     r2_mae_e = _test_regressor_oof(X_e, mae_arr[idx_e], ts_e)
     gain_mae = r2_mae_e - r2_mae_g
 
-    # To lighten Phase 1 default compute, optionally skip reversal & mfe here
-    # Assuming the caller may want these, but we can set them to 0.0 by default or return what was requested.
-    gain_rev = 0.0
-    gain_mfe = 0.0
+    # Full Reversal Predictability for MR model regimes
+    auc_rev_g = _test_classifier_oof(X_g, rev_target[idx_g], ts_g)
+    auc_rev_e = _test_classifier_oof(X_e, rev_target[idx_e], ts_e)
+    gain_rev = auc_rev_e - auc_rev_g
+
+    # Full MFE Predictability for TP proxy
+    r2_mfe_g = _test_regressor_oof(X_g, mfe_arr[idx_g], ts_g)
+    r2_mfe_e = _test_regressor_oof(X_e, mfe_arr[idx_e], ts_e)
+    gain_mfe = r2_mfe_e - r2_mfe_g
 
     gain_max = max(gain_cont, gain_rev, gain_mae, gain_mfe)
 


### PR DESCRIPTION
Fixes an explicit bias in the `mask_optimiser.py` pipeline where it solely optimized for Trend Following regimes and completely ignored Mean Reversion viability.

### What
- Removed hardcoded `gain_rev = 0.0` and `gain_mfe = 0.0` in `_compute_conditional_learnability`.
- Implemented correct calculations using `_test_classifier_oof` for `rev_target` and `_test_regressor_oof` for `mfe_arr`.

### Why
- The pipeline's Mean Reversion models (e.g., `long_mr_H2`) were critically failing out-of-sample (PR-AUC 0.468, Worst Fold -8.6%) because the baseline dataset (Layer 0 mask) they were training on was explicitly selected only for Trend Continuation characteristics. This fix ensures MR regimes are actually discovered and scored by Layer 0.

### Impact
- Slower but accurate execution of the Layer 0 optimization phase. Downstream MR models will now receive significantly cleaner, structurally distinct MR regimes to train on, which is the primary prerequisite for fixing the fold robustness issues.

---
*PR created automatically by Jules for task [6304745853029050505](https://jules.google.com/task/6304745853029050505) started by @remyroche*