### PR TITLE
Add cross-sectional out-of-sample symbol holdout mechanism

### DIFF
--- a/extreme_price_movements/config.py
+++ b/extreme_price_movements/config.py
@@ -871,6 +871,7 @@ CFG = {
     "borrow_apr": 0.20,
 
     "oos_holdout_days": 730,   # Enforce >= 2 years OOS holdout for robust signal evaluation
+    "oos_holdout_symbols": [], # Symbols to completely exclude from training (keep strictly for walk-forward)
 
     # Trailing Profit Risk Params (used in backtest & live, all vol-scaled)
     # Target absolute: TP ~2%, SL ~0.7% (with median barrier_pct ~4%)

--- a/extreme_price_movements/training.py
+++ b/extreme_price_movements/training.py
@@ -2494,9 +2494,14 @@ def generate_exhaustion_history(
     tprint(f"Entering function: generate_exhaustion_history in training.py")
     train_end = ts_end - pd.Timedelta(hours=lookback_hours)
     train_len = cfg["exh_train_lookback_hours"]
+
+    train_syms_exh = [s for s in syms if s not in cfg.get("oos_holdout_symbols", [])]
+    if len(train_syms_exh) < len(syms):
+        tprint(f"Exhaustion training: dropped {len(syms) - len(train_syms_exh)} OOS holdout symbols.")
+
     tprint("Generating UP history...")
     X_up, y_up, w_up, _ = build_exhaustion_Xy(
-        panel, feats, mkt_gates, cfg, train_end, train_len, syms, model_direction="up"
+        panel, feats, mkt_gates, cfg, train_end, train_len, train_syms_exh, model_direction="up"
     )
     model_up = None
     arr_oof_up = None
@@ -2510,7 +2515,7 @@ def generate_exhaustion_history(
 
     tprint("Generating DOWN history...")
     X_dn, y_dn, w_dn, _ = build_exhaustion_Xy(
-        panel, feats, mkt_gates, cfg, train_end, train_len, syms, model_direction="down"
+        panel, feats, mkt_gates, cfg, train_end, train_len, train_syms_exh, model_direction="down"
     )
     model_dn = None
     arr_oof_dn = None
@@ -5428,6 +5433,18 @@ def generate_label_datasets(
         tprint(
             f"OOS holdout: excluded last {oos_days} days (cutoff={cutoff}). Candidates: {n_before} -> {n_after}"
         )
+
+    # Apply OOS holdout: exclude specific symbols entirely from training
+    oos_syms = cfg.get("oos_holdout_symbols", [])
+    if oos_syms and cached_cand_mask is not None:
+        drop_syms = [s for s in oos_syms if s in cached_cand_mask.columns]
+        if drop_syms:
+            n_before = cached_cand_mask.sum().sum()
+            cached_cand_mask.loc[:, drop_syms] = False
+            n_after = cached_cand_mask.sum().sum()
+            tprint(
+                f"OOS holdout: excluded {len(drop_syms)} symbols ({drop_syms[:5]}...). Candidates: {n_before} -> {n_after}"
+            )
 
     # 1. Spike Anatomy (2 GMM models: Best & Worst)
     for mode in ["best", "worst"]:
@@ -11260,6 +11277,13 @@ def optimize_risk_params(
     if cand_mask is None:
         tprint("No candidates found.")
         return cfg
+
+    oos_syms = cfg.get("oos_holdout_symbols", [])
+    if oos_syms and cand_mask is not None:
+        drop_syms = [s for s in oos_syms if s in cand_mask.columns]
+        if drop_syms:
+            cand_mask.loc[:, drop_syms] = False
+            tprint(f"Risk optimization: excluded {len(drop_syms)} OOS holdout symbols.")
 
     # Ensure ts is a Timestamp and handle potential timezone mismatch with index
     ts = pd.Timestamp(ts)


### PR DESCRIPTION
# Implement OOS Symbol Holdout

The user requested a clean way to keep data (period/symbols) untouched through the training steps strictly for walk-forward validation. The pipeline already handled the temporal dimension via `oos_holdout_days`, but lacked a cross-sectional exclusion mechanism.

This PR adds `oos_holdout_symbols` configuration to allow explicit exclusion of validation symbols during the training phase.

Changes:
- Added `oos_holdout_symbols` setting (default `[]`) to `config.py`.
- Updated `training.py::generate_label_datasets` to drop these symbols from `cached_cand_mask` dynamically, mirroring the existing `oos_holdout_days` implementation.
- Filtered out holdout symbols in `training.py::generate_exhaustion_history` for model fitting, while retaining them in the full target index for backtest prediction generation.
- Added mask zeroing logic for holdout symbols to `training.py::optimize_risk_params`.
- Verified that backtesting loops in `pipeline_steps.py` will still naturally generate signals for the holdout symbols.

---
*PR created automatically by Jules for task [12545159308543055987](https://jules.google.com/task/12545159308543055987) started by @remyroche*