### PR TITLE
Update inference to 15m loop

### DIFF
--- a/extreme_price_movements/inference/feature_generator.py
+++ b/extreme_price_movements/inference/feature_generator.py
@@ -244,6 +244,12 @@ def get_inference_required_feature_keys(model_bundle: Dict[str, Any]) -> Set[str
         if isinstance(bucket_cfg, dict):
             required.update(bucket_cfg.get("feature_names", []) or [])
 
+    from extreme_price_movements.config import POSITION_SIZER_V2_FEATURE_CONFIG
+    required.update(POSITION_SIZER_V2_FEATURE_CONFIG.get("shared_feature_keys", []))
+    required.update(POSITION_SIZER_V2_FEATURE_CONFIG.get("model1_edge_feature_keys", []))
+    required.update(POSITION_SIZER_V2_FEATURE_CONFIG.get("model2_downside_feature_keys", []))
+    required.update(POSITION_SIZER_V2_FEATURE_CONFIG.get("model3_uncertainty_feature_keys", []))
+
     # Keep a small set of always-needed raw features used across inference glue.
     required.update(
         {


### PR DESCRIPTION
Update inference main loop to 15m loop, adjusting `data_fetcher.py` appropriately to overlap 1h blocks.

---
*PR created automatically by Jules for task [800458954264386188](https://jules.google.com/task/800458954264386188) started by @remyroche*