### PR TITLE
Fix logical, statistical, and leakage bugs in `mask_optimiser.py`

### DIFF
--- a/extreme_price_movements/mask_optimiser.py
+++ b/extreme_price_movements/mask_optimiser.py
@@ -1561,22 +1561,16 @@ def quick_ridge_auc(
     if len(np.unique(y_event)) < 2:
         return 0.5
 
-    X_event = features_df[event_mask].copy()
-    # Replace inf and impute nan
-    X_event = X_event.replace([np.inf, -np.inf], np.nan)
-    X_event = X_event.fillna(X_event.median())
-    X_event = X_event.fillna(0.0) # Fallback
-
-    # Scale features
-    from sklearn.preprocessing import StandardScaler
-    scaler = StandardScaler()
-    X_scaled = scaler.fit_transform(X_event)
-
+    # We extract unscaled data first to avoid temporal leakage
+    X_event_raw = features_df[event_mask].copy().replace([np.inf, -np.inf], np.nan)
     # Mapping global indices to event indices
     global_to_local = np.full(len(event_mask), -1, dtype=np.int32)
     global_to_local[event_mask] = np.arange(np.sum(event_mask))
 
     oof_preds = np.full(len(y_event), np.nan, dtype=np.float32)
+
+    from sklearn.preprocessing import StandardScaler
+    from sklearn.linear_model import RidgeClassifier
 
     for tr, va in folds:
         # Get event-only indices
@@ -1589,9 +1583,19 @@ def quick_ridge_auc(
         if len(tr_local) < 5 or len(va_local) < 2:
             continue
 
-        X_tr = X_scaled[tr_local]
+        # Impute and scale *inside* the fold using only training data
+        X_tr_df = X_event_raw.iloc[tr_local].copy()
+        X_va_df = X_event_raw.iloc[va_local].copy()
+
+        tr_median = X_tr_df.median()
+        X_tr_df = X_tr_df.fillna(tr_median).fillna(0.0)
+        X_va_df = X_va_df.fillna(tr_median).fillna(0.0)
+
+        scaler = StandardScaler()
+        X_tr = scaler.fit_transform(X_tr_df)
+        X_va = scaler.transform(X_va_df)
+
         y_tr = y_event[tr_local]
-        X_va = X_scaled[va_local]
 
         if len(np.unique(y_tr)) < 2:
             # Can't fit on single class
@@ -1599,7 +1603,6 @@ def quick_ridge_auc(
             oof_preds[va_local] = np.mean(y_tr)
             continue
 
-        from sklearn.linear_model import RidgeClassifier
         clf = RidgeClassifier(alpha=1.0)
         clf.fit(X_tr, y_tr)
 
@@ -2209,8 +2212,20 @@ def _rolling_robust_z_1d(x: np.ndarray, window: int) -> np.ndarray:
         if len(valid) > 0:
             med = np.median(valid)
             mad = np.median(np.abs(valid - med))
-            eps = 1e-6
-            out[i] = (x[i] - med) / (1.4826 * mad + eps)
+
+            if mad < 1e-12:
+                # Fallback to standard deviation if MAD is extremely small (constant area)
+                if len(valid) > 1:
+                    std = np.std(valid)
+                    denom = std if std > 1e-12 else 1e-6
+                else:
+                    denom = 1e-6
+            else:
+                denom = 1.4826 * mad + 1e-6
+
+            z = (x[i] - med) / denom
+            # Clamp to prevent explosion
+            out[i] = max(min(z, 10.0), -10.0)
     return out
 
 def compute_robust_z_for_groups(x: np.ndarray, asset_groups: Dict[int, np.ndarray], window: int) -> np.ndarray:
@@ -2533,12 +2548,13 @@ def _generate_event_masks_fast(
 
     if candidate["family"] in ("volatility_expansion", "compression_transition", "volume"):
         # These are magnitude / expansion indicators. They don't have inherent up/down logic themselves.
-        # But we must populate both mask_h and mask_l, because the caller filters by `_get_side_mask(mode, mask_h, mask_l)`.
-        # So an expansion trigger > 1.8 applies to BOTH up and down modes!
+        # We route them to mask_h or mask_l based on the concurrent price action direction.
         if direction == "gt":
             trigger = valid_mask & (feature_vals >= threshold)
-            mask_h = trigger
-            mask_l = trigger
+            up_move = zc.get("up", np.zeros_like(feature_vals))
+            dn_move = zc.get("dn", np.zeros_like(feature_vals))
+            mask_h = trigger & (up_move >= dn_move)
+            mask_l = trigger & (dn_move >= up_move)
 
     elif candidate["family"] == "structure":
         # breakout_distance_up_atr > 1.4 -> price went UP -> mask_h
@@ -2788,34 +2804,18 @@ def _build_shared_cache(
 def _phase1_subsample_indices(
     shared: Dict[str, Any], cfg: Dict[str, Any], seed: int = 42
 ) -> np.ndarray:
-    symbol_uniques = shared["symbol_uniques"]
     symbol_codes = shared["symbol_codes"]
-    day_ids = shared["day_ids"]
     n_total = symbol_codes.shape[0]
 
-    min_phase1_rows = int(cfg.get("phase1_min_subsample_rows", 20_000))
+    max_phase1_rows = int(cfg.get("phase1_max_subsample_rows", 20_000))
 
-    symbol_frac = float(cfg.get("stage1_symbol_fraction", 0.35))
-    history_frac = float(cfg.get("stage1_history_fraction", 0.35))
-
-    # Scale fractions up if the combined subsample would be too small.
-    expected_rows = n_total * symbol_frac * history_frac
-    if expected_rows < min_phase1_rows and n_total > 0:
-        scale = min(min_phase1_rows / max(expected_rows, 1.0), 1.0 / (symbol_frac * history_frac))
-        symbol_frac = min(1.0, symbol_frac * scale)
-        history_frac = min(1.0, history_frac * scale)
-
-    selected_symbols = _rng_sample_fraction(
-        list(range(symbol_uniques.shape[0])), frac=symbol_frac, seed=seed
-    )
-    symbol_mask = np.isin(symbol_codes, np.asarray(selected_symbols, dtype=np.int32))
-
-    history_mask = _sample_history_fraction_mask(day_ids, frac=history_frac, seed=seed)
-    result = symbol_mask & history_mask
-
-    # Final safety net: if still too small, use all rows.
-    if int(np.sum(result)) < min(min_phase1_rows, n_total):
+    if n_total <= max_phase1_rows:
         return np.ones(n_total, dtype=bool)
+
+    rng = np.random.RandomState(seed)
+    indices = rng.choice(n_total, size=max_phase1_rows, replace=False)
+    result = np.zeros(n_total, dtype=bool)
+    result[indices] = True
     return result
 
 
@@ -3962,17 +3962,15 @@ def _run_mode_search(
         return {"status": "failed", "reason": f"no_phase1_candidates_{mode}"}
 
     df1 = pd.DataFrame(phase1_rows)
+    disp_edge_z = _zscore_np(df1["dispersion_to_edge_ratio"].values.astype(np.float32))
+    disp_edge_z[np.isnan(disp_edge_z)] = 3.0  # Assign heavy penalty to missing/infinite dispersion
+
     df1["phase1_proxy_score"] = (
         0.20 * _zscore_np(df1["active_days_fraction"].values)
         + 0.15 * _zscore_np(df1["regime_distinctness_score"].values)
         + 0.15 * _zscore_np(np.log1p(df1["total_events"].values.astype(np.float32)))
         + 0.30 * _zscore_np(df1["basic_directionality_edge_event_vs_non_event"].values)
-        - 0.30
-        * _zscore_np(
-            np.nan_to_num(
-                df1["dispersion_to_edge_ratio"].values.astype(np.float32), nan=1e6
-            )
-        )
+        - 0.30 * disp_edge_z
         - 0.15 * _zscore_np(df1["fold_continuation_rate_std"].values)
         - 0.10 * _zscore_np(df1["fold_event_count_std"].values)
     )
@@ -4260,7 +4258,7 @@ def _run_mode_search(
             np.maximum(
                 np.nan_to_num(
                     df2["dispersion_to_edge_ratio"].astype(np.float32).values,
-                    nan=1e6,
+                    nan=100.0,
                 ),
                 0.0,
             )
@@ -5167,7 +5165,7 @@ def _run_mode_search(
                 np.maximum(
                     np.nan_to_num(
                         df_short["dispersion_to_edge_ratio"].astype(np.float32).values,
-                        nan=1e6,
+                        nan=100.0,
                     ),
                     0.0,
                 )

--- a/tests/test_mask_optimiser.py
+++ b/tests/test_mask_optimiser.py
@@ -78,10 +78,7 @@ def test_build_temporal_folds_fallback():
 
 def test_phase1_subsample_equivalence():
     from extreme_price_movements.mask_optimiser import _generate_event_masks_fast
-    up_move = np.random.rand(100)
-    dn_move = np.random.rand(100)
-    rolling_std_up = np.random.rand(100)
-    rolling_std_dn = np.random.rand(100)
+
     asset_ids = np.zeros(100, dtype=np.int32)
     asset_ids[50:] = 1
     asset_groups = {
@@ -89,13 +86,29 @@ def test_phase1_subsample_equivalence():
         1: np.where(asset_ids == 1)[0].astype(np.int32),
     }
 
+    # Setup dummy features and z-cache
+    feature_vals = np.random.rand(100)
+    zc_full = {
+        "dummy_feat": feature_vals,
+        "up": np.random.rand(100),
+        "dn": np.random.rand(100)
+    }
+
+    candidate = {
+        "feature_base": "dummy_feat",
+        "family": "momentum",
+        "direction": "gt",
+        "threshold": 0.5
+    }
+
     # Phase 1 mask: only take 1 asset
     phase1_mask = asset_ids == 0
 
     # Generate full then slice
     m_h_f, m_l_f = _generate_event_masks_fast(
-        "std_threshold", 1.0, up_move, dn_move,
-        rolling_std_up, rolling_std_dn, asset_groups, 2
+        candidate=candidate,
+        zc=zc_full,
+        asset_groups=asset_groups
     )
     m_h_sub = m_h_f[phase1_mask]
 
@@ -120,15 +133,17 @@ def test_phase1_subsample_equivalence():
         "symbol_uniques": np.array(["A", "B"]),
     }
     phase1_shared = _build_phase_local_shared(shared, phase1_mask)
+
+    zc_local = {
+        "dummy_feat": zc_full["dummy_feat"][phase1_mask],
+        "up": zc_full["up"][phase1_mask],
+        "dn": zc_full["dn"][phase1_mask]
+    }
+
     m_h_local, _ = _generate_event_masks_fast(
-        "std_threshold",
-        1.0,
-        up_move[phase1_mask],
-        dn_move[phase1_mask],
-        rolling_std_up[phase1_mask],
-        rolling_std_dn[phase1_mask],
-        phase1_shared["asset_groups"],
-        2,
+        candidate=candidate,
+        zc=zc_local,
+        asset_groups=phase1_shared["asset_groups"]
     )
     assert np.array_equal(m_h_local, m_h_sub)
 


### PR DESCRIPTION
1. **Fix 1:** Remove the 35% random subsample in Phase 1 and replace it with a uniform random sample capped at `phase1_max_rows` (default 20,000) so that the universe evaluated in Phase 1 matches Phase 2 while saving compute.
2. **Fix 2:** Address the duplication of `magnitude_positive_only` features by conditionally routing the expansion metric triggers to `mask_h` and `mask_l` based on whether the cumulative price action over the window was predominantly up (`up_move >= dn_move`) or down (`dn_move >= up_move`).
3. **Fix 3:** Fix the `eps=1e-6` zero-MAD denominator collapse in `_rolling_robust_z_1d` by falling back to the standard deviation of valid window points if MAD is < 1e-12, and clamping the output Z-scores to `[-10.0, 10.0]` to prevent explosion.
4. **Fix 4:** Refactor `quick_ridge_auc` so that feature imputation and standard scaling happens strictly inside the fold loops (`tr`, `va`) instead of globally beforehand, preventing temporal leakage.
5. **Fix 5:** Remove the `np.nan_to_num(..., nan=1e6)` logic for `dispersion_to_edge_ratio` in Phase 1 that broke `_zscore_np`, replacing it with manual assignment of +3.0 to NaNs in the calculated Z-score array. Lower the `nan=1e6` fill value to `100.0` in Phase 2 and 3/4 `noise_penalty` calculations to keep the penalty bounded.

---
*PR created automatically by Jules for task [11665746821901472764](https://jules.google.com/task/11665746821901472764) started by @remyroche*