### PR TITLE
⚡ Bolt: [performance improvement] Replace .iterrows() with .itertuples() in inference

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,7 @@ Action: Replaced the iterative loop with a fully vectorized approach using `np.s
 ## 2026-03-04 - Parallelizing Numba Rolling Functions (Mean, Std)
 Learning: Even when using a fast 1D Numba JIT compiled function via `apply_to_matrix(df, func)`, looping sequentially over each column sequentially in Python adds considerable overhead for large DataFrames.
 Action: Rewrote core rolling window functions (`_numba_rolling_std_nan_safe` and `_numba_rolling_mean_nan_safe`) as 2D functions running natively across all columns simultaneously using Numba's `@jit(parallel=True)` and `prange`. Updating `apply_to_frame` to intercept and delegate to this new parallel approach provided a transparent optimization with massive speedup for feature generation pipelines without altering any logic in features.py.
+
+## 2026-03-04 - Iterating DataFrames safely using itertuples
+Learning: Pandas `.iterrows()` is known to be significantly slower than `.itertuples()` for iterating over DataFrame rows, due to the overhead of boxing rows into Series objects on every iteration.
+Action: Replaced `.iterrows()` with `.itertuples()` in `extreme_price_movements/inference/run_inference.py` during OCO policy evaluation, which speeds up sequential traversal of bar data. Note that attributes are accessed via `row.column_name` instead of `row["column_name"]`.

--- a/cache/feature_transforms/unknown/meta.json
+++ b/cache/feature_transforms/unknown/meta.json
@@ -1,0 +1,1 @@
+{"version": 1, "roll_window": 10, "winsor_qt": 0.05, "sigma_k": 1.6448536269514722, "rows": 100, "cols": ["a", "b"], "first_ts": "0", "last_ts": "99"}

--- a/extreme_price_movements/inference/run_inference.py
+++ b/extreme_price_movements/inference/run_inference.py
@@ -752,11 +752,10 @@ def _evaluate_oco_policy(symbol: str, position_state: Dict[str, Any], ohlcv_5m: 
         mfe_threshold = float(params.get("mfe_early_exit_threshold", 0.02))
         last_bar_ts = bars.index[-1]
 
-        for bar_ts, row in bars.iterrows():
-            bar_open = float(row["open"])
-            bar_high = float(row["high"])
-            bar_low = float(row["low"])
-            bar_close = float(row["close"])
+        for row in bars.itertuples():
+            bar_high = float(row.high)
+            bar_low = float(row.low)
+            bar_close = float(row.close)
 
             if side == "long":
                 mfe = max(mfe, (bar_high - entry_price) / max(entry_price, 1e-12))

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,19 @@
+--- extreme_price_movements/inference/run_inference.py
++++ extreme_price_movements/inference/run_inference.py
+@@ -752,11 +752,11 @@
+         mfe_threshold = float(params.get("mfe_early_exit_threshold", 0.02))
+         last_bar_ts = bars.index[-1]
+
+-        for bar_ts, row in bars.iterrows():
+-            bar_open = float(row["open"])
+-            bar_high = float(row["high"])
+-            bar_low = float(row["low"])
+-            bar_close = float(row["close"])
++        for row in bars.itertuples():
++            bar_open = float(row.open)
++            bar_high = float(row.high)
++            bar_low = float(row.low)
++            bar_close = float(row.close)
+
+             if side == "long":
+                 mfe = max(mfe, (bar_high - entry_price) / max(entry_price, 1e-12))

--- a/patch2.diff
+++ b/patch2.diff
@@ -1,0 +1,10 @@
+--- extreme_price_movements/inference/run_inference.py
++++ extreme_price_movements/inference/run_inference.py
+@@ -753,7 +753,6 @@
+         last_bar_ts = bars.index[-1]
+
+         for row in bars.itertuples():
+-            bar_open = float(row.open)
+             bar_high = float(row.high)
+             bar_low = float(row.low)
+             bar_close = float(row.close)


### PR DESCRIPTION
💡 What: Replaced `.iterrows()` with `.itertuples()` in `_evaluate_oco_policy` in `extreme_price_movements/inference/run_inference.py`. Removed unused variable `bar_open`. Added a note to `.jules/bolt.md`.
🎯 Why: Pandas `.iterrows()` is extremely slow for sequential traversal of DataFrame rows because it creates a Series object for each row. Iterating via `.itertuples()` returns namedtuples, avoiding this overhead, which is critical in loops evaluating active OCO positions.
📊 Impact: Measurable reduction in overhead when evaluating 5-minute OHLCV data sequentially during inference.
🔬 Measurement: Run inference in live mode with active positions and monitor the time taken to process `run_challenger_monitor`.

---
*PR created automatically by Jules for task [9959258720100644027](https://jules.google.com/task/9959258720100644027) started by @remyroche*