### PR TITLE
⚡ Bolt: Replace np.vectorize with fast native np.unique for label mapping

### DIFF
--- a/src/training/steps/market_analysis/clusters/iterative_optimization.py
+++ b/src/training/steps/market_analysis/clusters/iterative_optimization.py
@@ -6752,9 +6752,9 @@ class IterativeOptimization:
     def _relabel_compact(self, labels: np.ndarray) -> np.ndarray:
         """Compact labels to eliminate 0-size clusters."""
         try:
-            u = np.unique(labels)
-            m = {old: i for i, old in enumerate(u)}
-            return np.vectorize(m.get)(labels)
+            if labels.size == 0:
+                return labels
+            return np.unique(labels, return_inverse=True)[1]
         except Exception as e:
             tprint(f"Relabel compact failed: {e}", "ERROR")
             return labels
@@ -7659,9 +7659,9 @@ class IterativeOptimization:
     def _relabel_compact(self, labels):
         """Remove empty labels and remap to 0..K-1 to avoid size=0 clusters & DBI=inf."""
         import numpy as np
-        u = np.unique(labels)
-        remap = {cid:i for i, cid in enumerate(u)}
-        return np.vectorize(remap.get)(labels)
+        if labels.size == 0:
+            return labels
+        return np.unique(labels, return_inverse=True)[1]
 
     def _balanced_two_way_split(self, labels, cid):
         """Split cluster ensuring both children meet MIN_SIZE requirement."""
@@ -7696,10 +7696,9 @@ class IterativeOptimization:
     def _prune_empty(self, labels):
         """Remove empty/zero-size labels and reindex 0..K-1 to avoid size=0 clusters and DBI=inf."""
         import numpy as np
-        u = np.unique(labels)
-        remap = {cid:i for i, cid in enumerate(u)}
-        out = np.vectorize(remap.get)(labels)
-        return out
+        if labels.size == 0:
+            return labels
+        return np.unique(labels, return_inverse=True)[1]
 
     def _size_penalty(self, dest_after: float, mean_size: float, soft_cap: float,
                       over_w: float = 0.02, cap_w: float = 0.05, near: float = 0.90) -> float:
@@ -7962,11 +7961,18 @@ class IterativeOptimization:
         """
         import numpy as np
         # keep largest child as parent label; new labels for others
-        unique, counts = np.unique(child_labels, return_counts=True)
+        unique, inv, counts = np.unique(child_labels, return_inverse=True, return_counts=True)
         kept = unique[np.argmax(counts)]
         order = [kept] + [u for u in unique if u != kept]
-        remap = {u:i for i,u in enumerate(order)}
-        child_labels = np.vectorize(remap.get)(child_labels)
+
+        if child_labels.size > 0:
+            # unique returns sorted elements. We can map from the sorted index (inv) to our desired order.
+            # `inv` has values 0 .. len(unique)-1 corresponding to the sorted `unique` array.
+            # We want to map `unique[i]` to `remap[unique[i]]`.
+            remap = {u: i for i, u in enumerate(order)}
+            # Create a small mapping array where index is the `inv` value
+            small_lookup = np.array([remap[u] for u in unique])
+            child_labels = small_lookup[inv]
 
         next_lab = int(assignments.max()) + 1
         assignments = assignments.copy()


### PR DESCRIPTION
💡 **What:** Replaced four instances of `np.vectorize(dict.get)` in `src/training/steps/market_analysis/clusters/iterative_optimization.py` with native `np.unique(..., return_inverse=True)` approaches.
🎯 **Why:** `np.vectorize` is essentially a Python loop under the hood, making it a severe performance bottleneck for mapping large clustering labels.
📊 **Impact:** Expect highly accelerated computation times during array compaction and subset relabeling by executing the operations purely in C.
🔬 **Measurement:** Verify tests run properly, and benchmark the cluster generation methods over large data subsets to see the improvement.

---
*PR created automatically by Jules for task [9074446615186345710](https://jules.google.com/task/9074446615186345710) started by @remyroche*