### PR TITLE
Fix MDI Feature Selection Max Samples Capping

### DIFF
--- a/extreme_price_movements/feature_selection_extreme_events.py
+++ b/extreme_price_movements/feature_selection_extreme_events.py
@@ -1008,7 +1008,7 @@ def mdi_feature_selection_v3(
 
         # Subsampling Logic - Limit to 5K events max for MDI
         n_star = min(
-            int(max(256, analysis_max_samples)),
+            min(N, int(max(256, analysis_max_samples))),
             max(1200, 150 * p, 80 * end_features),
         )
 

--- a/extreme_price_movements/model_mr.py
+++ b/extreme_price_movements/model_mr.py
@@ -86,6 +86,7 @@ class MRModel:
             selector_target="regression",
             selector_loss="huber",
             analysis_n_estimators=500,
+            analysis_max_samples=int(min(X.shape[0], 3000)),
             end_features=n_stage1,
             cumulative_cap=0.98,
             min_share=0.001,

--- a/extreme_price_movements/model_tf.py
+++ b/extreme_price_movements/model_tf.py
@@ -92,6 +92,7 @@ class TFModel:
             selector_target="regression",
             selector_loss="huber",
             analysis_n_estimators=500,
+            analysis_max_samples=int(min(X.shape[0], 3000)),
             end_features=n_stage1,
             cumulative_cap=0.98,
             min_share=0.001,

--- a/extreme_price_movements/training.py
+++ b/extreme_price_movements/training.py
@@ -7057,9 +7057,7 @@ def train_meta_models_from_artifacts(
                     analysis_n_estimators=int(
                         _head_cfg.get("analysis_n_estimators", 160)
                     ),
-                    analysis_max_samples=int(
-                        _head_cfg.get("analysis_max_samples", 2500)
-                    ),
+                    analysis_max_samples=int(min(len(_X_clean), _head_cfg.get("analysis_max_samples", 2500))),
                     min_samples_leaf_pct=float(
                         _head_cfg.get("min_samples_leaf_pct", 0.02)
                     ),
@@ -11582,7 +11580,7 @@ def train_models_from_artifacts(datasets, cfg, train_meta=True, train_base=True)
             ),
             selector_emit_report=bool(_base_sel_cfg.get("selector_emit_report", True)),
             analysis_n_estimators=int(_base_sel_cfg.get("analysis_n_estimators", 192)),
-            analysis_max_samples=int(_base_sel_cfg.get("analysis_max_samples", 3000)),
+            analysis_max_samples=int(min(len(X.iloc[_sel_idx]), _base_sel_cfg.get("analysis_max_samples", 3000))),
             min_samples_leaf_pct=float(
                 _base_sel_cfg.get("min_samples_leaf_pct", 0.015)
             ),
@@ -11913,9 +11911,7 @@ def train_models_from_artifacts(datasets, cfg, train_meta=True, train_base=True)
                         analysis_n_estimators=int(
                             _base_sel_cfg.get("analysis_n_estimators", 192)
                         ),
-                        analysis_max_samples=int(
-                            _base_sel_cfg.get("analysis_max_samples", 3000)
-                        ),
+                        analysis_max_samples=int(min(len(X.iloc[_sel_idx]), _base_sel_cfg.get("analysis_max_samples", 3000))),
                         min_samples_leaf_pct=float(
                             _base_sel_cfg.get("min_samples_leaf_pct", 0.015)
                         ),


### PR DESCRIPTION
This ensures that MDI feature selection `analysis_max_samples` does not exceed the actual number of available samples. It properly wraps bounds in `min(N, int(max(256, analysis_max_samples)))` in the `mdi_feature_selection_v3` loop and sets appropriate `analysis_max_samples` limits for TF and MR models and all base/meta training steps where this is called.

---
*PR created automatically by Jules for task [6259957906745188846](https://jules.google.com/task/6259957906745188846) started by @remyroche*