### PR TITLE
Fix MDI feature selection sampling limits

### DIFF
--- a/extreme_price_movements/feature_selection_extreme_events.py
+++ b/extreme_price_movements/feature_selection_extreme_events.py
@@ -1006,11 +1006,20 @@ def mdi_feature_selection_v3(
     while True:
         p = len(current_features)
 
-        # Subsampling Logic - Limit to 5K events max for MDI
+        # Subsampling Logic
+        _tgt = str(_sel_target).lower().strip()
+        if _tgt in {"classification", "binary", "clf"}:
+            cap = int(max(256, analysis_max_samples * 2.0))
+        else:
+            cap = int(max(256, analysis_max_samples))
+
         n_star = min(
-            int(max(256, analysis_max_samples)),
+            cap,
             max(1200, 150 * p, 80 * end_features),
         )
+
+        # Ensure requested samples do not exceed available rows
+        n_star = int(min(N, n_star))
 
         if n_star < N:
              # Systematic sampling

--- a/extreme_price_movements/quantile_feature_selection_extreme_events.py
+++ b/extreme_price_movements/quantile_feature_selection_extreme_events.py
@@ -171,12 +171,21 @@ def mdi_feature_selection_v3(
     alpha: float = 0.85,
     dual_alpha: Sequence[float] = (0.7, 0.85),
     tail_q: float = 0.80,
+    analysis_max_samples: int = 3000,
     **_: dict,
 ) -> MDISelectionResult:
     if not isinstance(X, pd.DataFrame):
         raise TypeError("X must be a pandas DataFrame")
     y_np = np.asarray(y, dtype=float)
     target = end_features if end_features is not None else max(min_features, min(max_features, int(np.sqrt(max(1, X.shape[1])) * 3)))
+
+    N = len(X)
+    # Ensure requested samples do not exceed available rows, quantile is considered regression
+    n_star = int(min(N, max(256, analysis_max_samples)))
+    if n_star < N:
+        indices_sub = np.linspace(0, N - 1, n_star, dtype=int)
+        X = X.iloc[indices_sub].copy()
+        y_np = y_np[indices_sub]
 
     uni = _univariate_tail_screen(X, y_np, target_count=target, tail_q=tail_q)
     pre_cols = uni.index.tolist()


### PR DESCRIPTION
Resolves an issue where `mdi_feature_selection_v3` lacked consistent upper-bound sample caps, potentially causing memory/speed issues, and failed to apply distinct caps for binary vs regression targets.
- Used a higher cap (`analysis_max_samples * 2.0`) for binary/classification targets.
- Applied `np.linspace` deterministic subsampling for `quantile_feature_selection_extreme_events.py` before screening, up to `analysis_max_samples`.

---
*PR created automatically by Jules for task [2531038787533717926](https://jules.google.com/task/2531038787533717926) started by @remyroche*