### PR TITLE
Fix position sizing logic rank inversion

### DIFF
--- a/extreme_price_movements/position_sizer_v2.py
+++ b/extreme_price_movements/position_sizer_v2.py
@@ -78,17 +78,17 @@ def _apply_sizing_mode(
     
     if sizing_mode == "linear":
         # Linear scaling based on rank percentile
-        ranks = np.argsort(np.argsort(-scores))  # Rank descending
+        ranks = np.argsort(np.argsort(scores))  # Rank ascending so highest score gets highest size
         pctiles = ranks / max(1, len(scores) - 1)
         sizes = base_position_size * (0.5 + 0.5 * pctiles)
     elif sizing_mode == "concave":
         # Concave (diminishing returns) - conservative sizing
-        ranks = np.argsort(np.argsort(-scores))
+        ranks = np.argsort(np.argsort(scores))
         pctiles = ranks / max(1, len(scores) - 1)
         sizes = base_position_size * np.sqrt(pctiles)
     elif sizing_mode == "convex":
         # Convex (accelerating) - aggressive sizing for top ranks
-        ranks = np.argsort(np.argsort(-scores))
+        ranks = np.argsort(np.argsort(scores))
         pctiles = ranks / max(1, len(scores) - 1)
         sizes = base_position_size * (pctiles ** 2)
     else:


### PR DESCRIPTION
Fixes a logical bug in `_apply_sizing_mode` where rank percentiles were inverted, causing high-confidence predictions to be given the smallest position sizes. Also reviewed all related recent features (PortfolioManager dynamic thresholds, isotonic calibration, inference backtesting filters) and found them correctly implemented.

---
*PR created automatically by Jules for task [6313143966124934274](https://jules.google.com/task/6313143966124934274) started by @remyroche*