### PR TITLE
fix: resolve NameError when trailing is disabled in simulation

### DIFF
--- a/extreme_price_movements/policy_optimiser.py
+++ b/extreme_price_movements/policy_optimiser.py
@@ -832,7 +832,7 @@ def _simulate_tpsl_from_paths_unified(
                 else:
                     # Simple TP exit (no trailing)
                     # Exit when we first hit the TP level
-                    if tp_hit[i_idx]:
+                    if high_ret[i_idx] >= tp_dist_a[i_idx]:
                         bar_exit[i_idx] = tp_dist_a[i_idx]
         
         # If no hit, use close for last bar


### PR DESCRIPTION
- Fixes `tp_hit` undefined variable bug in `_simulate_tpsl_from_paths_unified` inside `policy_optimiser.py`.
- Replaces undefined boolean array reference with direct conditional evaluation `high_ret[i_idx] >= tp_dist_a[i_idx]`.

---
*PR created automatically by Jules for task [11510594718221285354](https://jules.google.com/task/11510594718221285354) started by @remyroche*