### PR TITLE
Regime feature refactor; add regime features, training diagnostics & sample guards; document MDI+HPO flow

### DIFF
--- a/docs/base_training_mdi_hpo_flow.md
+++ b/docs/base_training_mdi_hpo_flow.md
@@ -1,0 +1,60 @@
+# Base Training MDI + HPO Flow
+
+This note documents how `extreme_price_movements/run_pipeline.py base_training`
+handles feature selection (MDI) and hyper-parameter optimization (HPO).
+
+## Stage order
+
+The base pipeline stage is:
+
+1. MDI feature selection
+2. ExtraTrees base HPO
+3. Final base model training
+
+Implementation reference: `run_base_hpo_step` in
+`extreme_price_movements/pipeline_steps.py`.
+
+## Scope granularity
+
+MDI and HPO are run per concrete base scope:
+
+- `strategy_id`
+- `horizon`
+- optional historical dataset suffix variants (`""`, `_tight`, `_wide`) when
+  present
+
+## MDI selection behavior
+
+`mdi_feature_selection_v3` is used for base selection. The selector combines
+multiple quality signals, including:
+
+- support in top-ranked subsets
+- global importance
+- fold stability
+- frequency support
+- interaction support
+
+A final weighted score is then used to rank and keep features.
+
+## HPO objective (base ExtraTrees path)
+
+Base HPO uses `run_base_extratrees_hpo`.
+
+Per trial:
+
+- runs purged cross-validation
+- computes top-30% IC per fold from model probabilities
+- aggregates fold IC via mean and standard deviation
+
+Optimization target:
+
+- maximize `mean_ic - std_ic`
+
+This favors high signal at the decision tail while penalizing unstable
+configurations.
+
+## Persistence and reuse
+
+Selected features and HPO outputs are persisted under artifacts. During base
+training, persisted HPO-selected feature sets are loaded when available;
+otherwise MDI is recomputed.

--- a/extreme_price_movements/config.py
+++ b/extreme_price_movements/config.py
@@ -361,7 +361,7 @@ TIME_FEATURE_KEYS = [
     "cos_dow",
 ]
 
-RIDGE_FEATURE_META = {
+CONTINUOUS_REGIME_FEATURES = {
     # Trend features
     "ema20_gt_ema50": {"family": "trend", "type": "binary"},
     "ema50_gt_ema200": {"family": "trend", "type": "binary"},
@@ -419,9 +419,19 @@ RIDGE_FEATURE_META = {
         "family": "path_structure",
         "type": "continuous",
     },
+    # Additional 24h+ / structural regime features
+    "rv_24h": {"family": "volatility", "type": "continuous"},
+    "dist_ema_fast": {"family": "trend", "type": "continuous"},
+    "range_24h_pct": {"family": "compression", "type": "continuous"},
+    "spectral_entropy_ret_24": {"family": "path_structure", "type": "continuous"},
+    "volume_entropy_24": {"family": "liquidity", "type": "continuous"},
+    "path_efficiency_24": {"family": "path_structure", "type": "continuous"},
+    "amihud_illiq": {"family": "liquidity", "type": "continuous"},
+    "amihud_z": {"family": "liquidity", "type": "continuous"},
+    "coherence_24": {"family": "path_structure", "type": "continuous"},
 }
 
-RIDGE_FEATURE_COLS = list(RIDGE_FEATURE_META.keys())
+RIDGE_FEATURE_COLS = list(CONTINUOUS_REGIME_FEATURES.keys())
 
 CONTINUOUS_TRIGGER_COLS = [
     "range_atr",
@@ -774,7 +784,8 @@ CFG = {
     # Canonical set is [1, 2, 4] hours. H1 added for entry timing; H8 removed.
     "label_horizons_hours": CANON_HORIZONS,
     "base_geometry_archetypes": ["tight", "balanced", "wide"],
-    "base_geometry_train_variants": True,
+    "base_geometry_train_variants": False,
+    "base_skip_primary_variant": False,
     "base_geometry_grr_topk": 12,
     "base_geometry_learnability_weight": 0.75,
     "base_geometry_geometry_weight": 0.25,
@@ -802,6 +813,7 @@ CFG = {
     "train_lookback_hours": 24 * 365 * 4,  # 4 years
     "val_lookback_hours": 24 * 7,  # 7d validation (time-split, no leakage)
     "min_train_samples": 200,
+    "base_min_samples_hard_floor": 3000,
     # Sample caps (symbol-balanced subsampling when exceeded)
     "base_fit_max_samples": 0,
     "base_selector_max_samples": 30000,

--- a/extreme_price_movements/lgbm_based_mask_generation.py
+++ b/extreme_price_movements/lgbm_based_mask_generation.py
@@ -30,11 +30,10 @@ os.environ.setdefault("LOKY_MAX_CPU_COUNT", "3")
 from extreme_price_movements.config import (
     CFG,
     CONTINUOUS_LOCATION_COLS,
+    CONTINUOUS_REGIME_FEATURES,
     CONTINUOUS_TRIGGER_COLS,
     LOC_CONTINUOUS_FAMILY_MAP,
     RIDGE_FEATURE_COLS,
-    RIDGE_FEATURE_META,
-    TEST_FEATURE_KEYS,
     TIME_FEATURE_KEYS,
 )
 from extreme_price_movements.data_store import (
@@ -2069,11 +2068,15 @@ class FeatureProcessor:
 
     @staticmethod
     def _regime_source_type(source_name: str) -> str:
-        return str(RIDGE_FEATURE_META.get(source_name, {}).get("type", "continuous"))
+        return str(
+            CONTINUOUS_REGIME_FEATURES.get(source_name, {}).get("type", "continuous")
+        )
 
     @staticmethod
     def _regime_source_family(source_name: str) -> str:
-        return str(RIDGE_FEATURE_META.get(source_name, {}).get("family", "unknown"))
+        return str(
+            CONTINUOUS_REGIME_FEATURES.get(source_name, {}).get("family", "unknown")
+        )
 
     @staticmethod
     def _is_reserved_target_side_feature(source_name: str) -> bool:
@@ -2255,11 +2258,7 @@ class FeatureProcessor:
         # 3. Regime Features (continuous -> hybrid booleanize)
         if "regime" in active_groups:
             time_keys_set = set(TIME_FEATURE_KEYS)
-            regime_sources = sorted(
-                list(
-                    (set(RIDGE_FEATURE_COLS) | set(TEST_FEATURE_KEYS)) - time_keys_set
-                )
-            )
+            regime_sources = sorted(list(set(RIDGE_FEATURE_COLS) - time_keys_set))
             _add_continuous_features_as_booleans(regime_sources, "regime")
 
         # 4. Extra Binary Features (e.g. Stage A Contexts)
@@ -2536,8 +2535,8 @@ class FeatureProcessor:
         source_name = kwargs.get("source_name", name)
         regime_family = None
         if group == "regime":
-            if source_name in RIDGE_FEATURE_META:
-                regime_family = RIDGE_FEATURE_META[source_name].get("family")
+            if source_name in CONTINUOUS_REGIME_FEATURES:
+                regime_family = CONTINUOUS_REGIME_FEATURES[source_name].get("family")
             else:
                 regime_family = kwargs.get("source_family", "unknown")
 

--- a/extreme_price_movements/ridge_regime_event_assessment.py
+++ b/extreme_price_movements/ridge_regime_event_assessment.py
@@ -7,7 +7,10 @@ from sklearn.model_selection import TimeSeriesSplit
 from lightgbm import LGBMRegressor
 from scipy.stats import spearmanr
 
-from extreme_price_movements.config import RIDGE_FEATURE_META, RIDGE_FEATURE_COLS
+from extreme_price_movements.config import (
+    CONTINUOUS_REGIME_FEATURES,
+    RIDGE_FEATURE_COLS,
+)
 
 # =========================================================
 # DATACLASSES
@@ -310,7 +313,7 @@ def select_promising_regime_variables(
     Selects top features avoiding family concentration and high collinearity.
     """
     selected = []
-    family_counts = {f["family"]: 0 for f in RIDGE_FEATURE_META.values()}
+    family_counts = {f["family"]: 0 for f in CONTINUOUS_REGIME_FEATURES.values()}
 
     # We only check correlation against already selected continuous features
     selected_continuous_cols = []
@@ -325,7 +328,9 @@ def select_promising_regime_variables(
         if pd.isna(importance) or importance < min_importance:
             continue
 
-        meta = RIDGE_FEATURE_META.get(fname, {"family": "unknown", "type": "continuous"})
+        meta = CONTINUOUS_REGIME_FEATURES.get(
+            fname, {"family": "unknown", "type": "continuous"}
+        )
         family = meta["family"]
         ftype = meta["type"]
 
@@ -382,7 +387,9 @@ def build_phase3_conditioner_seeds(
         fname = row["feature"]
         coef = row["coef"]
 
-        meta = RIDGE_FEATURE_META.get(fname, {"family": "unknown", "type": "continuous"})
+        meta = CONTINUOUS_REGIME_FEATURES.get(
+            fname, {"family": "unknown", "type": "continuous"}
+        )
         direction = "positive" if coef > 0 else "negative"
 
         thresholds = None

--- a/extreme_price_movements/training.py
+++ b/extreme_price_movements/training.py
@@ -1020,6 +1020,9 @@ def _fit_direct_extratrees_base_model(
             )
 
     oof_probs = np.full(len(y_hard), np.nan, dtype=np.float64)
+    fold_class_diagnostics = []
+    folds_with_insufficient_samples = 0
+    folds_with_single_class_pred = 0
     for fold_i, (train_idx, val_idx) in enumerate(cached_splits, start=1):
         if train_idx.size == 0 or val_idx.size == 0:
             continue
@@ -1027,12 +1030,33 @@ def _fit_direct_extratrees_base_model(
         X_val = X_np[val_idx] if isinstance(X_np, np.ndarray) else X.iloc[val_idx]
         y_tr = y_hard[train_idx]
         y_val = y_hard[val_idx]
+        train_pos = int(np.sum(y_tr))
+        train_neg = int(len(y_tr) - train_pos)
+        val_pos = int(np.sum(y_val))
+        val_neg = int(len(y_val) - val_pos)
+        fold_has_insufficient = (
+            train_pos < 2 or train_neg < 2 or val_pos < 2 or val_neg < 2
+        )
+        if fold_has_insufficient:
+            folds_with_insufficient_samples += 1
+        fold_class_diagnostics.append(
+            {
+                "fold": int(fold_i),
+                "n_train": int(len(y_tr)),
+                "n_val": int(len(y_val)),
+                "train_pos": train_pos,
+                "train_neg": train_neg,
+                "val_pos": val_pos,
+                "val_neg": val_neg,
+                "insufficient_class_support": bool(fold_has_insufficient),
+            }
+        )
         w_tr = sample_weight_arr[train_idx] if sample_weight_arr is not None else None
         est = clone(candidate)
         race._fit_model(est, X_tr, y_tr, sample_weight=w_tr)
         _proba_out = est.predict_proba(X_val)
         if _proba_out.shape[1] < 2:
-            oof_probs[val_idx] = 0.5
+            folds_with_single_class_pred += 1
             continue
         probs_raw = np.asarray(_proba_out[:, 1], dtype=np.float64)
         if sample_weight_arr is not None:
@@ -1047,7 +1071,6 @@ def _fit_direct_extratrees_base_model(
             f"  Direct ExtraTrees fold {fold_i}/{len(cached_splits)} complete: n_train={train_idx.size}, n_val={val_idx.size}"
         )
 
-    oof_probs = np.nan_to_num(oof_probs, nan=0.5)
     oof_probs_raw = np.asarray(oof_probs, dtype=np.float32).copy()
     p_unweighted_all, p_weighted_all = compute_prevalences(y_hard, sample_weight_arr)
     race._used_sample_weight_ = sample_weight_arr is not None
@@ -1126,9 +1149,17 @@ def _fit_direct_extratrees_base_model(
         race.platt_calibrator_ = None
         tprint(f"Direct ExtraTrees calibration fallback to identity: {exc}")
 
+    oof_probs_eval = np.asarray(race.oof_probs, dtype=np.float64)
+    finite_eval = np.isfinite(oof_probs_eval)
+    if np.any(finite_eval):
+        eval_fill = float(np.nanmean(oof_probs_eval[finite_eval]))
+    else:
+        eval_fill = float(np.mean(y_hard)) if len(y_hard) else 0.5
+    oof_probs_eval = np.where(finite_eval, oof_probs_eval, eval_fill)
+
     sel = calculate_selection_score(
         y_hard,
-        race.oof_probs,
+        oof_probs_eval,
         returns_arr,
         sample_weight=sample_weight_arr,
         w_bss=0.20,
@@ -1137,18 +1168,18 @@ def _fit_direct_extratrees_base_model(
     )
     try:
         auc = (
-            float(roc_auc_score(y_hard, race.oof_probs))
+            float(roc_auc_score(y_hard, oof_probs_eval))
             if len(np.unique(y_hard)) > 1
             else 0.5
         )
     except Exception:
         auc = 0.5
     try:
-        ll = float(log_loss(y_hard, np.clip(race.oof_probs, 1e-7, 1 - 1e-7)))
+        ll = float(log_loss(y_hard, np.clip(oof_probs_eval, 1e-7, 1 - 1e-7)))
     except Exception:
         ll = float("nan")
     try:
-        acc = float(accuracy_score(y_hard, race.oof_probs >= 0.5))
+        acc = float(accuracy_score(y_hard, oof_probs_eval >= 0.5))
     except Exception:
         acc = float("nan")
     if (
@@ -1172,12 +1203,40 @@ def _fit_direct_extratrees_base_model(
     else:
         ic = 0.0
     top10_mask = topk_mask(
-        race.oof_probs, 0.10, groups=groups_arr if groups_arr is not None else None
+        oof_probs_eval, 0.10, groups=groups_arr if groups_arr is not None else None
     )
     top30_mask = topk_mask(
-        race.oof_probs, 0.30, groups=groups_arr if groups_arr is not None else None
+        oof_probs_eval, 0.30, groups=groups_arr if groups_arr is not None else None
     )
-    curve = calibration_curve_bins(y_hard, race.oof_probs, n_bins=10)
+    curve = calibration_curve_bins(y_hard, oof_probs_eval, n_bins=10)
+    class_pos = int(np.sum(y_hard))
+    class_neg = int(len(y_hard) - class_pos)
+    class_imbalance_pct = (
+        float(min(class_pos, class_neg) / max(len(y_hard), 1)) * 100.0
+    )
+    oof_nan_count = int(np.sum(~np.isfinite(np.asarray(race.oof_probs, dtype=np.float64))))
+    training_diagnostics = {
+        "n_total": int(len(y_hard)),
+        "class_counts": {"neg": class_neg, "pos": class_pos},
+        "class_imbalance_minority_pct": class_imbalance_pct,
+        "fold_count_requested": int(n_splits),
+        "fold_count_realized": int(len(cached_splits)),
+        "folds_with_insufficient_class_support": int(folds_with_insufficient_samples),
+        "folds_with_single_class_predictions": int(folds_with_single_class_pred),
+        "oof_nan_count": oof_nan_count,
+        "oof_nan_ratio": float(oof_nan_count / max(len(y_hard), 1)),
+        "fold_class_diagnostics": fold_class_diagnostics,
+    }
+    if folds_with_insufficient_samples > 0:
+        tprint(
+            f"WARNING: {kind_name} has {folds_with_insufficient_samples}/{len(cached_splits)} folds "
+            "with insufficient class support."
+        )
+    if folds_with_single_class_pred > 0:
+        tprint(
+            f"WARNING: {kind_name} has {folds_with_single_class_pred}/{len(cached_splits)} folds "
+            "with single-class probability output; OOF kept as NaN for those folds."
+        )
     dm = {
         "score": float(sel.get("Selection_Score", 0.0)),
         "rank_score": float(sel.get("Selection_Score", 0.0)),
@@ -1214,6 +1273,7 @@ def _fit_direct_extratrees_base_model(
         "calibration_profile": calibration_profile(curve),
         "oof_probs": np.asarray(race.oof_probs, dtype=np.float32).copy(),
         "oof_raw": np.asarray(oof_probs_raw, dtype=np.float32).copy(),
+        "training_diagnostics": training_diagnostics,
     }
     degeneracy = _base_oof_degeneracy_summary(oof_probs_raw, race.oof_probs)
     dm["degeneracy"] = degeneracy
@@ -1260,8 +1320,6 @@ def _fit_direct_extratrees_base_model(
             refit_oof[val_idx] = apply_logit_shift(
                 probs_raw, delta_logit_fold, eps=1e-6
             )
-        refit_oof = np.nan_to_num(refit_oof, nan=0.5)
-
         refit_calibrated, refit_calibrator, refit_cal_method = (
             _safe_binary_calibrate(refit_oof, y_hard, min_unique=20, min_samples=100)
         )
@@ -1721,6 +1779,7 @@ def _base_model_report_entry(
     top5_features=None,
     top10_features=None,
 ):
+    training_diag = dict(dm.get("training_diagnostics", {}) or {})
     prev = float(np.mean(y_bin))
     prev = float(np.clip(prev, 1e-7, 1 - 1e-7))
     base_brier = prev * (1.0 - prev)
@@ -1907,8 +1966,6 @@ def _base_model_report_entry(
 
     metrics = {
         "auc": calibrated_auc,
-        "raw_auc": raw_auc,
-        "calibrated_auc": calibrated_auc,
         "ic": raw_ic_bin,
         "ic_ret": raw_ic_ret,
         "median_ic_t30": median_ic_t30,
@@ -1938,6 +1995,25 @@ def _base_model_report_entry(
         **timeout_metrics,
     }
     degeneracy = dm.get("degeneracy", {})
+    constant_prediction_warning = bool(
+        degeneracy.get("is_degenerate", False)
+        and any(
+            str(r).startswith("cal_unique_lt_")
+            or str(r).startswith("raw_unique_lt_")
+            or str(r).startswith("cal_std_lt_")
+            or str(r).startswith("raw_std_lt_")
+            for r in (degeneracy.get("reasons", []) or [])
+        )
+    )
+    training_warnings = []
+    if constant_prediction_warning:
+        training_warnings.append("constant_or_near_constant_predictions")
+    if int(training_diag.get("folds_with_insufficient_class_support", 0)) > 0:
+        training_warnings.append("folds_with_insufficient_class_support")
+    if int(training_diag.get("folds_with_single_class_predictions", 0)) > 0:
+        training_warnings.append("single_class_fold_predictions")
+    if float(training_diag.get("class_imbalance_minority_pct", 100.0)) < 10.0:
+        training_warnings.append("severe_class_imbalance_lt_10pct_minority")
 
     return {
         "model": model_name,
@@ -1946,10 +2022,11 @@ def _base_model_report_entry(
         "score": float(dm.get("rank_score", dm.get("score", 0.0))),
         "checks": {k: {"pass": bool(v), "emoji": _emoji(v)} for k, v in checks.items()},
         "metrics": metrics,
-        "raw_auc": raw_auc,
-        "calibrated_auc": calibrated_auc,
         "degenerate": bool(degeneracy.get("is_degenerate", False)),
         "degeneracy": degeneracy,
+        "training_diagnostics": training_diag,
+        "constant_prediction_warning": constant_prediction_warning,
+        "training_warnings": training_warnings,
         "passed": bool(all(checks.values())),
         "top5_features": list(top5_features or []),
         "top10_features": list(top10_features or []),
@@ -6873,33 +6950,50 @@ def generate_label_datasets(
         for H in strategy_horizons.get(strategy_id, []):
             H_int = int(H)
 
-            if not bool(cfg.get("base_geometry_train_variants", True)):
-                tprint(
-                    f"Skipping classifier label cell {strategy_id}_H{H_int}: "
-                    "base_geometry_train_variants=False but tight/wide are mandatory."
-                )
-                continue
+            if bool(cfg.get("base_geometry_train_variants", True)):
+                _missing_required = [
+                    _v
+                    for _v in _required_geometry_variants
+                    if (H_int, strategy_id, _v) not in tb_cache
+                ]
+                if _missing_required:
+                    tprint(
+                        f"Skipping classifier label cell {strategy_id}_H{H_int}: "
+                        f"missing required geometry variants={_missing_required}."
+                    )
+                    continue
 
-            _missing_required = [
-                _v
-                for _v in _required_geometry_variants
-                if (H_int, strategy_id, _v) not in tb_cache
-            ]
-            if _missing_required:
-                tprint(
-                    f"Skipping classifier label cell {strategy_id}_H{H_int}: "
-                    f"missing required geometry variants={_missing_required}."
-                )
-                continue
-
-            for _variant in _required_geometry_variants:
+                for _variant in _required_geometry_variants:
+                    tasks.append(
+                        (
+                            H_int,
+                            side,
+                            k,
+                            strategy_id,
+                            _variant,
+                            move_bucket,
+                            strategy_label,
+                            cand_filter,
+                            feat_key,
+                            extra_feature_keys,
+                            fixed_tp,
+                            fixed_sl,
+                        )
+                    )
+            else:
+                if (H_int, strategy_id) not in tb_cache:
+                    tprint(
+                        f"Skipping classifier label cell {strategy_id}_H{H_int}: "
+                        "missing primary geometry payload."
+                    )
+                    continue
                 tasks.append(
                     (
                         H_int,
                         side,
                         k,
                         strategy_id,
-                        _variant,
+                        None,
                         move_bucket,
                         strategy_label,
                         cand_filter,
@@ -12256,6 +12350,7 @@ def train_models_from_artifacts(datasets, cfg, train_meta=True, train_base=True)
     base_variant_models = {}
     min_base_fit_features = int(cfg.get("base_min_fit_features_guard", 8))
     skip_primary_alpha = bool(cfg.get("base_skip_primary_variant", True))
+    base_min_samples_hard_floor = int(cfg.get("base_min_samples_hard_floor", 3000))
 
     def _log_feature_matrix_state(label, X_df, selected=None):
         cols_now = list(X_df.columns) if hasattr(X_df, "columns") else []
@@ -12290,7 +12385,8 @@ def train_models_from_artifacts(datasets, cfg, train_meta=True, train_base=True)
         if (
             df_variant is None
             or df_variant.empty
-            or len(df_variant) < cfg["min_train_samples"] // 4
+            or len(df_variant)
+            < max(int(cfg["min_train_samples"] // 4), base_min_samples_hard_floor)
         ):
             return None
         y = df_variant["__y_bin__"].values.astype(np.float32)
@@ -12622,7 +12718,9 @@ def train_models_from_artifacts(datasets, cfg, train_meta=True, train_base=True)
                         continue
 
                     df = datasets[key]
-                    if df.empty or len(df) < cfg["min_train_samples"] // 4:
+                    if df.empty or len(df) < max(
+                        int(cfg["min_train_samples"] // 4), base_min_samples_hard_floor
+                    ):
                         continue
 
                     _base_cap = int(cfg.get("base_fit_max_samples", 150000))
@@ -13679,16 +13777,7 @@ def train_models_from_artifacts(datasets, cfg, train_meta=True, train_base=True)
             continue
         models_by_h = conf.get("models_by_h", {})
         if not models_by_h:
-            # Fallback: single-model legacy format
-            models_by_h = {
-                conf.get("H", 4): {
-                    "model": conf["model"],
-                    "feat_cols": conf["feat_cols"],
-                    "top5_features": conf.get("top5_features", []),
-                    "top10_features": conf.get("top10_features", []),
-                    "deployable": not bool(conf.get("downstream_blocked", False)),
-                }
-            }
+            continue
         for H_rep, h_info in models_by_h.items():
             ds_key = f"train_{kind}_{H_rep}"
             if ds_key not in datasets:
@@ -13709,10 +13798,8 @@ def train_models_from_artifacts(datasets, cfg, train_meta=True, train_base=True)
                 # Use per-model OOF predictions from detailed_metrics, not the winner's OOF
                 oof_probs = dm.get("oof_probs")
                 if oof_probs is None:
-                    # Fallback to winner's OOF if per-model not available (legacy)
-                    oof_probs = np.asarray(race.oof_probs, dtype=float)
-                else:
-                    oof_probs = np.asarray(oof_probs, dtype=float)
+                    continue
+                oof_probs = np.asarray(oof_probs, dtype=float)
                 n = min(len(y_bin), len(oof_probs), len(y_ret))
                 y_bin_model, oof_probs_model, y_ret_model = (
                     y_bin[:n],


### PR DESCRIPTION
### Motivation
- Centralize and extend continuous regime feature metadata to support new 24h+/structural regime features and simplify lookups across the codebase.
- Improve robustness of base classifier training by enforcing a hard floor on minimum samples, detecting degenerate/single-class folds, and surfacing richer diagnostics for downstream reporting.
- Document the base MDI (MDI feature selection) + HPO flow so the intended stage order and objectives are explicit and discoverable.

### Description
- Add `docs/base_training_mdi_hpo_flow.md` describing the base pipeline stage order, MDI selection behavior, HPO objective, and artifact reuse.
- Replace `RIDGE_FEATURE_META` with `CONTINUOUS_REGIME_FEATURES`, add multiple new regime features, and update `RIDGE_FEATURE_COLS` to be `list(CONTINUOUS_REGIME_FEATURES.keys())` in `config.py`.
- Update feature preparation and mask generation (`lgbm_based_mask_generation.py`) and regime assessment (`ridge_regime_event_assessment.py`) to use `CONTINUOUS_REGIME_FEATURES` and remove references to legacy test keys.
- Add `base_min_samples_hard_floor` config and enforce it in training entrypoints (dataset-level guards and variant training) to avoid training on very small datasets.
- Harden `_fit_direct_extratrees_base_model` and surrounding training code to collect per-fold class diagnostics, detect insufficient class support and single-class predictions, impute OOF values for evaluation, add `training_diagnostics` to metrics, and emit warnings for degenerate conditions.
- Adjust base geometry variant control flow to respect `base_geometry_train_variants`/`base_skip_primary_variant` and avoid legacy fallbacks in quality reporting.

### Testing
- Ran the project's unit test suite with `pytest -q`, and the tests covering training and feature modules passed.
- Executed a short pipeline smoke training run of `train_models_from_artifacts` on a small local dataset to validate guards and diagnostics, and the smoke run completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e09df4cee0832fb102f5aab5d2d1cb)