### PR TITLE
Include utility_policy_optimisation in train pool and update allocation targets

### DIFF
--- a/extreme_price_movements/slice_plan_store.py
+++ b/extreme_price_movements/slice_plan_store.py
@@ -239,7 +239,7 @@ def _assign_interleaved_week_periods(
         return
 
     shared_groups = [
-        ("train_base", "train_meta"),
+        ("train_base", "train_meta", "utility_policy_optimisation"),
     ]
 
     pool_for_stage: dict[str, str] = {}
@@ -368,11 +368,11 @@ def load_or_build_slice_plan(
         planner_config = SlicePlannerConfig.fast_defaults(schema=EventSchema())
 
     allocation_targets = {
-        "train_base": 0.55,
-        "train_meta": 0.55,
-        "sizer_train": 0.20,
-        "utility_policy_optimisation": 0.15,
-        "holdout_strategy_eval": 0.10
+        "train_base": 0.70,
+        "train_meta": 0.70,
+        "sizer_train": 0.25,
+        "utility_policy_optimisation": 0.70,
+        "holdout_strategy_eval": 0.05,
     }
 
     # Try to load existing


### PR DESCRIPTION
### Motivation
- Ensure `utility_policy_optimisation` shares the same scheduling pool as `train_base`/`train_meta` so week assignment and capacity accounting treat them as a single group.
- Shift allocation weightings to increase training-related capacity and reduce holdout proportion to better match expected workload distribution.

### Description
- Add `"utility_policy_optimisation"` to the `shared_groups` tuple alongside `"train_base"` and `"train_meta"` in `slice_plan_store.py` so pooling logic groups them together. 
- Update the `allocation_targets` map in `load_or_build_slice_plan` to change percentages for `train_base`, `train_meta`, `sizer_train`, `utility_policy_optimisation`, and `holdout_strategy_eval`.
- These changes affect how `pool_for_stage`/`pool_weight` are computed and therefore influence week window assignment via `_largest_remainder_counts` and the interleaving logic.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b6e66808832fae490cbc8a560d2f)