### PR TITLE
Add tree-ensemble uncertainty features to model race/meta pipeline and stage-view filtering for policy optimiser

### DIFF
--- a/extreme_price_movements/engine.py
+++ b/extreme_price_movements/engine.py
@@ -1254,6 +1254,17 @@ def _build_side_score_df(ts_sig, feats, mkt_gates, model_bundle, cfg, current_po
                 mr_preds_list.append(_p)
                 mr_h_preds[f"pred_mr_H{_h}"] = _p
                 mr_h_preds[f"pred_H{_h}"] = _p # Also generic name for meta-compat
+                if hasattr(_m, "predict_tree_uncertainty_features"):
+                    try:
+                        _u = _m.predict_tree_uncertainty_features(_X)
+                        for _uk, _uv in _u.items():
+                            _vals = np.asarray(_uv, dtype=np.float32)
+                            mr_h_preds[f"pred_mr_H{_h}_{_uk}"] = _vals
+                            if f"pred_H{_h}_{_uk}" not in mr_h_preds:
+                                mr_h_preds[f"pred_H{_h}_{_uk}"] = _vals
+                            mr_h_preds[f"base_H{_h}_{_uk}"] = _vals
+                    except Exception:
+                        pass
             p_mr = np.mean(mr_preds_list, axis=0) if mr_preds_list else np.zeros(len(grp))
         else:
             X_mr_pred = grp_mr.reindex(columns=fcols_mr, fill_value=0.0).fillna(0.0).astype(np.float32)
@@ -1272,6 +1283,20 @@ def _build_side_score_df(ts_sig, feats, mkt_gates, model_bundle, cfg, current_po
                 tf_h_preds[f"pred_tf_H{_h}"] = _p
                 if f"pred_H{_h}" not in mr_h_preds: # avoid collision
                      tf_h_preds[f"pred_H{_h}"] = _p
+                if hasattr(_m, "predict_tree_uncertainty_features"):
+                    try:
+                        _u = _m.predict_tree_uncertainty_features(_X)
+                        for _uk, _uv in _u.items():
+                            _vals = np.asarray(_uv, dtype=np.float32)
+                            tf_h_preds[f"pred_tf_H{_h}_{_uk}"] = _vals
+                            if (
+                                f"pred_H{_h}_{_uk}" not in mr_h_preds
+                                and f"pred_H{_h}_{_uk}" not in tf_h_preds
+                            ):
+                                tf_h_preds[f"pred_H{_h}_{_uk}"] = _vals
+                            tf_h_preds[f"base_H{_h}_{_uk}"] = _vals
+                    except Exception:
+                        pass
             p_tf = np.mean(tf_preds_list, axis=0) if tf_preds_list else np.zeros(len(grp))
         else:
             X_tf_pred = grp_tf.reindex(columns=fcols_tf, fill_value=0.0).fillna(0.0).astype(np.float32)

--- a/extreme_price_movements/model_race.py
+++ b/extreme_price_movements/model_race.py
@@ -335,28 +335,203 @@ class ModelRace(BaseEstimator, ClassifierMixin):
 
         model.fit(X_tr, y_tr, **fit_kwargs)
 
-    def _tree_sigma_features(self, model, X):
-        """Return tree-ensemble dispersion features for a fitted model.
+    _TREE_UNCERTAINTY_KEYS = (
+        "pred_mean",
+        "pred_std",
+        "pred_iqr",
+        "pred_cv",
+        "pred_std_robust",
+        "vote_entropy",
+        "vote_margin",
+        "vote_top_gap",
+        "leaf_support_mean",
+        "leaf_support_median",
+        "leaf_support_std",
+        "leaf_target_std_mean",
+        "leaf_target_iqr_mean",
+        "leaf_target_var_mean",
+        "leaf_centroid_dist_mean",
+        "leaf_centroid_dist_median",
+        "leaf_centroid_dist_cv",
+    )
 
-        The base race only uses ExtraTrees, so we can compute the per-tree vote
-        spread directly from the fitted estimators. Fallbacks are NaN when the
-        model does not expose tree estimators.
-        """
+    @staticmethod
+    def _nan_tree_feature_dict(n: int) -> dict[str, np.ndarray]:
+        return {
+            k: np.full(n, np.nan, dtype=np.float32)
+            for k in ModelRace._TREE_UNCERTAINTY_KEYS
+        }
+
+    def _build_leaf_context(
+        self, model, X_train: np.ndarray, y_train: np.ndarray
+    ) -> list[dict[str, np.ndarray]] | None:
         inner = model.estimator if isinstance(model, Float64Wrapper) else model
         estimators = getattr(inner, "estimators_", None)
         if not estimators:
-            n = len(X)
-            nan_vec = np.full(n, np.nan, dtype=np.float32)
-            return nan_vec, nan_vec
+            return None
+        if X_train is None or y_train is None or len(X_train) == 0:
+            return None
+
+        X_tr = np.asarray(X_train, dtype=np.float32)
+        y_tr = np.asarray(y_train, dtype=np.float32).reshape(-1)
+        context: list[dict[str, np.ndarray]] = []
+
+        for tree in estimators:
+            leaves = tree.apply(X_tr).astype(np.int32)
+            uniq, inv = np.unique(leaves, return_inverse=True)
+            n_leaf = len(uniq)
+            support = np.bincount(inv, minlength=n_leaf).astype(np.float32)
+            support_safe = np.maximum(support, 1.0)
+
+            y_sum = np.bincount(inv, weights=y_tr, minlength=n_leaf).astype(np.float32)
+            y_sq_sum = np.bincount(
+                inv, weights=np.square(y_tr), minlength=n_leaf
+            ).astype(np.float32)
+            y_mean = y_sum / support_safe
+            y_var = np.clip(y_sq_sum / support_safe - np.square(y_mean), 0.0, None)
+            y_std = np.sqrt(y_var, dtype=np.float32)
+            # Bernoulli-compatible IQR proxy from in-leaf positive rate.
+            y_iqr = np.where(
+                (y_mean > 0.25) & (y_mean < 0.75), 1.0, 0.0
+            ).astype(np.float32)
+
+            centroid = np.zeros((n_leaf, X_tr.shape[1]), dtype=np.float32)
+            for j in range(X_tr.shape[1]):
+                centroid[:, j] = (
+                    np.bincount(inv, weights=X_tr[:, j], minlength=n_leaf).astype(
+                        np.float32
+                    )
+                    / support_safe
+                )
+
+            context.append(
+                {
+                    "leaf_ids": uniq.astype(np.int32),
+                    "support": support.astype(np.float32),
+                    "target_std": y_std.astype(np.float32),
+                    "target_iqr": y_iqr.astype(np.float32),
+                    "target_var": y_var.astype(np.float32),
+                    "centroid": centroid.astype(np.float32),
+                }
+            )
+        return context
+
+    def _tree_uncertainty_features(
+        self,
+        model,
+        X,
+        *,
+        leaf_context: list[dict[str, np.ndarray]] | None = None,
+        X_train: np.ndarray | None = None,
+        y_train: np.ndarray | None = None,
+        eps: float = 1e-12,
+    ) -> dict[str, np.ndarray]:
+        inner = model.estimator if isinstance(model, Float64Wrapper) else model
+        estimators = getattr(inner, "estimators_", None)
+        n = len(X)
+        if not estimators:
+            return self._nan_tree_feature_dict(n)
+
+        X_np = np.asarray(X, dtype=np.float32)
         try:
-            tree_preds = np.stack([tree.predict(X) for tree in estimators], axis=1)
-            sigma = np.asarray(tree_preds.std(axis=1), dtype=np.float32)
-            sigma_robust = np.asarray(robust_sigma(tree_preds), dtype=np.float32)
-            return sigma, sigma_robust
+            tree_preds = np.column_stack([t.predict(X_np) for t in estimators]).astype(
+                np.float32
+            )
         except Exception:
-            n = len(X)
-            nan_vec = np.full(n, np.nan, dtype=np.float32)
-            return nan_vec, nan_vec
+            return self._nan_tree_feature_dict(n)
+
+        pred_mean = tree_preds.mean(axis=1).astype(np.float32)
+        pred_std = tree_preds.std(axis=1).astype(np.float32)
+        pred_iqr = np.subtract(
+            np.percentile(tree_preds, 75, axis=1),
+            np.percentile(tree_preds, 25, axis=1),
+            dtype=np.float32,
+        ).astype(np.float32)
+        pred_cv = (pred_std / (np.abs(pred_mean) + eps)).astype(np.float32)
+        pred_std_robust = np.asarray(robust_sigma(tree_preds), dtype=np.float32)
+
+        # Binary-vote uncertainty features.
+        votes = tree_preds
+        p_hat = votes.mean(axis=1).astype(np.float32)
+        p_hat = np.clip(p_hat, 0.0, 1.0)
+        vote_entropy = -(
+            p_hat * np.log(p_hat + eps) + (1.0 - p_hat) * np.log(1.0 - p_hat + eps)
+        ).astype(np.float32)
+        vote_margin = np.abs(p_hat - 0.5).astype(np.float32)
+        vote_top_gap = np.abs(2.0 * p_hat - 1.0).astype(np.float32)
+
+        if leaf_context is None and X_train is not None and y_train is not None:
+            try:
+                leaf_context = self._build_leaf_context(model, X_train, y_train)
+            except Exception:
+                leaf_context = None
+
+        n_trees = len(estimators)
+        leaf_support = np.full((n, n_trees), np.nan, dtype=np.float32)
+        leaf_target_std = np.full((n, n_trees), np.nan, dtype=np.float32)
+        leaf_target_iqr = np.full((n, n_trees), np.nan, dtype=np.float32)
+        leaf_target_var = np.full((n, n_trees), np.nan, dtype=np.float32)
+        leaf_centroid_dist = np.full((n, n_trees), np.nan, dtype=np.float32)
+
+        for i, tree in enumerate(estimators):
+            leaves = tree.apply(X_np).astype(np.int32)
+            leaf_support[:, i] = tree.tree_.n_node_samples[leaves].astype(np.float32)
+            if not leaf_context or i >= len(leaf_context):
+                continue
+            ctx = leaf_context[i]
+            leaf_ids = ctx["leaf_ids"]
+            pos = np.searchsorted(leaf_ids, leaves)
+            valid = (pos >= 0) & (pos < len(leaf_ids)) & (leaf_ids[pos] == leaves)
+            if not valid.any():
+                continue
+            vp = pos[valid]
+            leaf_target_std[valid, i] = ctx["target_std"][vp]
+            leaf_target_iqr[valid, i] = ctx["target_iqr"][vp]
+            leaf_target_var[valid, i] = ctx["target_var"][vp]
+            centroids = ctx["centroid"][vp]
+            diff = X_np[valid] - centroids
+            leaf_centroid_dist[valid, i] = np.sqrt(
+                np.sum(np.square(diff, dtype=np.float32), axis=1), dtype=np.float32
+            )
+
+        leaf_support_mean = np.nanmean(leaf_support, axis=1).astype(np.float32)
+        leaf_support_median = np.nanmedian(leaf_support, axis=1).astype(np.float32)
+        leaf_support_std = np.nanstd(leaf_support, axis=1).astype(np.float32)
+        leaf_target_std_mean = np.nanmean(leaf_target_std, axis=1).astype(np.float32)
+        leaf_target_iqr_mean = np.nanmean(leaf_target_iqr, axis=1).astype(np.float32)
+        leaf_target_var_mean = np.nanmean(leaf_target_var, axis=1).astype(np.float32)
+        leaf_centroid_dist_mean = np.nanmean(leaf_centroid_dist, axis=1).astype(
+            np.float32
+        )
+        leaf_centroid_dist_median = np.nanmedian(leaf_centroid_dist, axis=1).astype(
+            np.float32
+        )
+        leaf_centroid_dist_std = np.nanstd(leaf_centroid_dist, axis=1).astype(
+            np.float32
+        )
+        leaf_centroid_dist_cv = (
+            leaf_centroid_dist_std / (leaf_centroid_dist_mean + eps)
+        ).astype(np.float32)
+
+        return {
+            "pred_mean": pred_mean,
+            "pred_std": pred_std,
+            "pred_iqr": pred_iqr,
+            "pred_cv": pred_cv,
+            "pred_std_robust": pred_std_robust,
+            "vote_entropy": vote_entropy,
+            "vote_margin": vote_margin,
+            "vote_top_gap": vote_top_gap,
+            "leaf_support_mean": leaf_support_mean,
+            "leaf_support_median": leaf_support_median,
+            "leaf_support_std": leaf_support_std,
+            "leaf_target_std_mean": leaf_target_std_mean,
+            "leaf_target_iqr_mean": leaf_target_iqr_mean,
+            "leaf_target_var_mean": leaf_target_var_mean,
+            "leaf_centroid_dist_mean": leaf_centroid_dist_mean,
+            "leaf_centroid_dist_median": leaf_centroid_dist_median,
+            "leaf_centroid_dist_cv": leaf_centroid_dist_cv,
+        }
 
     def fit(self, X, y, sample_weight=None, returns=None, groups=None, symbols=None):
         """
@@ -485,8 +660,10 @@ class ModelRace(BaseEstimator, ClassifierMixin):
             fold_base_logloss = []
             fold_logloss_imp = []
             oof_model = np.full(len(y), np.nan, dtype=np.float64)
-            oof_sigma_trees = np.full(len(y), np.nan, dtype=np.float32)
-            oof_sigma_robust = np.full(len(y), np.nan, dtype=np.float32)
+            oof_tree_features = {
+                k: np.full(len(y), np.nan, dtype=np.float32)
+                for k in self._TREE_UNCERTAINTY_KEYS
+            }
 
             try:
                 for fold_i, (train_idx, val_idx) in enumerate(cached_splits):
@@ -574,11 +751,16 @@ class ModelRace(BaseEstimator, ClassifierMixin):
                         probs = probs_raw
 
                     oof_model[val_idx] = probs
-                    sigma_fold, sigma_robust_fold = self._tree_sigma_features(
-                        model_clone, X_val
+                    fold_tree_feats = self._tree_uncertainty_features(
+                        model_clone,
+                        X_val,
+                        X_train=X_tr,
+                        y_train=y_tr_fit,
                     )
-                    oof_sigma_trees[val_idx] = sigma_fold
-                    oof_sigma_robust[val_idx] = sigma_robust_fold
+                    for _k, _vals in fold_tree_feats.items():
+                        oof_tree_features[_k][val_idx] = np.asarray(
+                            _vals, dtype=np.float32
+                        )
                     
                     # w_bss=0.20: Enabled BSS in selection score
                     # We now compute weighted BSS for diagnostics
@@ -681,8 +863,12 @@ class ModelRace(BaseEstimator, ClassifierMixin):
                     "fold_brier": [float(x) for x in fold_brier],
                     "fold_base_logloss": [float(x) for x in fold_base_logloss],
                     "fold_logloss_imp": [float(x) for x in fold_logloss_imp],
-                    "oof_sigma_trees": oof_sigma_trees.copy().astype(np.float32),
-                    "oof_sigma_robust": oof_sigma_robust.copy().astype(np.float32),
+                    "oof_sigma_trees": oof_tree_features["pred_std"].copy().astype(np.float32),
+                    "oof_sigma_robust": oof_tree_features["pred_std_robust"].copy().astype(np.float32),
+                    **{
+                        f"oof_tree_{_k}": np.asarray(_v, dtype=np.float32).copy()
+                        for _k, _v in oof_tree_features.items()
+                    },
                     # Store Calibrated OOF for gate checks
                     "oof_probs": np.nan_to_num(oof_cal.copy(), nan=0.5).astype(np.float32),
                     # Store raw OOF for reference
@@ -1040,6 +1226,19 @@ class ModelRace(BaseEstimator, ClassifierMixin):
         # Use _fit_model so that class weights and other dynamics are applied correctly,
         # even without early stopping (no eval_set passed).
         self._fit_model(self.best_model, X, y_hard, sample_weight=sample_weight)
+        try:
+            _x_fit = (
+                X_np
+                if use_numpy
+                else X.to_numpy(dtype=np.float32, copy=False)
+                if hasattr(X, "to_numpy")
+                else np.asarray(X, dtype=np.float32)
+            )
+            self.best_model_leaf_context_ = self._build_leaf_context(
+                self.best_model, _x_fit, y_hard
+            )
+        except Exception:
+            self.best_model_leaf_context_ = None
 
         # 4. Post-refit recalibration
         # The refit model has a different distribution than the fold-specific OOF models.
@@ -1165,6 +1364,16 @@ class ModelRace(BaseEstimator, ClassifierMixin):
         # Return probability class 1 (rank score, not calibrated probability)
         return self.predict_proba(X)[:, 1]
 
+    def predict_tree_uncertainty_features(self, X):
+        """Compute tree-dispersion and leaf-local uncertainty features."""
+        if self.best_model is None:
+            return self._nan_tree_feature_dict(len(X))
+        return self._tree_uncertainty_features(
+            self.best_model,
+            X,
+            leaf_context=getattr(self, "best_model_leaf_context_", None),
+        )
+
     def strip_for_serialization(self):
         """Drop heavy internals not needed for inference or meta training."""
         for attr in ["race_sample_frac", "race_early_stopping_rounds",
@@ -1206,6 +1415,7 @@ class ModelRace(BaseEstimator, ClassifierMixin):
             "calibrator_": getattr(self, "calibrator_", None),
             "platt_calibrator_": getattr(self, "platt_calibrator_", None),
             "classes_": getattr(self.best_model, "classes_", np.array([0, 1])),
+            "best_model_leaf_context_": getattr(self, "best_model_leaf_context_", None),
             "model_file": fmt,
         }
         with open(os.path.join(directory, "sidecar.pkl"), "wb") as f:
@@ -1245,4 +1455,5 @@ class ModelRace(BaseEstimator, ClassifierMixin):
         obj._used_sample_weight_ = sc["_used_sample_weight_"]
         obj.calibrator_ = sc.get("calibrator_")
         obj.platt_calibrator_ = sc.get("platt_calibrator_")
+        obj.best_model_leaf_context_ = sc.get("best_model_leaf_context_")
         return obj

--- a/extreme_price_movements/pipeline_steps.py
+++ b/extreme_price_movements/pipeline_steps.py
@@ -2734,6 +2734,7 @@ def run_policy_optimiser_step(ts_sig, cfg):
         holdout_frac=holdout_frac,
         cost_pct=cost_pct,
         use_offset_optimiser=use_offset_optimiser,
+        stage_view=cfg.get("_active_stage_view"),
     )
     if result:
         tprint("POLICY OPTIMISER COMPLETE")

--- a/extreme_price_movements/policy_optimiser.py
+++ b/extreme_price_movements/policy_optimiser.py
@@ -452,6 +452,54 @@ def _attach_sizer_score(
     return merged
 
 
+def _filter_df_by_stage_view(
+    df: pd.DataFrame, stage_view: Optional[Dict[str, Any]]
+) -> pd.DataFrame:
+    """Apply symbol/time restrictions from a materialized stage view."""
+    if stage_view is None or df is None or df.empty:
+        return df
+
+    out = df.copy()
+    symbol_col = next((c for c in ("symbol", "__symbol__") if c in out.columns), None)
+    ts_col = next((c for c in ("timestamp", "__ts__", "t0") if c in out.columns), None)
+
+    allowed_symbols = stage_view.get("symbols")
+    if allowed_symbols is not None and symbol_col is not None:
+        out = out[out[symbol_col].astype(str).isin([str(s) for s in allowed_symbols])]
+
+    if ts_col is not None and not out.empty:
+        ts = pd.to_datetime(out[ts_col], utc=True, errors="coerce")
+
+        periods = stage_view.get("allowed_periods") or None
+        if periods:
+            mask = np.zeros(len(out), dtype=bool)
+            for period in periods:
+                if isinstance(period, dict):
+                    p_start = period.get("start_ts") or period.get("start")
+                    p_end = period.get("end_ts") or period.get("end")
+                elif isinstance(period, (list, tuple)) and len(period) >= 2:
+                    p_start, p_end = period[0], period[1]
+                else:
+                    continue
+                p_start = pd.to_datetime(p_start, utc=True, errors="coerce")
+                p_end = pd.to_datetime(p_end, utc=True, errors="coerce")
+                if pd.isna(p_start) or pd.isna(p_end) or p_end <= p_start:
+                    continue
+                mask |= (ts >= p_start) & (ts < p_end)
+            out = out.loc[mask]
+            ts = pd.to_datetime(out[ts_col], utc=True, errors="coerce")
+
+        start_ts = stage_view.get("allowed_start_ts")
+        end_ts = stage_view.get("allowed_end_ts")
+        if start_ts:
+            out = out[ts >= pd.to_datetime(start_ts, utc=True, errors="coerce")]
+            ts = pd.to_datetime(out[ts_col], utc=True, errors="coerce")
+        if end_ts:
+            out = out[ts <= pd.to_datetime(end_ts, utc=True, errors="coerce")]
+
+    return out
+
+
 def resolve_optimised_selection_frac(
     *, data_root: str, run_id: str, selected: Dict[str, Any]
 ) -> float:
@@ -1825,6 +1873,7 @@ def run_policy_optimisation(
     holdout_frac: float = 0.30,
     cost_pct: float = 0.003,
     use_offset_optimiser: bool = False,
+    stage_view: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     tprint("POLICY OPTIMISER START")
     selected_candidates = _load_strategy_candidates(data_root, run_id)
@@ -1837,7 +1886,22 @@ def run_policy_optimisation(
         return {}
 
     meta_oofs = load_meta_oof_predictions(data_root, run_id)
+    if stage_view:
+        filtered_meta: Dict[str, pd.DataFrame] = {}
+        for key, mdf in meta_oofs.items():
+            mdf_f = _filter_df_by_stage_view(mdf, stage_view)
+            if not mdf_f.empty:
+                filtered_meta[key] = mdf_f
+        meta_oofs = filtered_meta
+        if not meta_oofs:
+            tprint("Policy optimiser stage filtering removed all meta OOF rows.")
+            return {}
+
     sizer_scores = _load_sizer_oof_scores(data_root, run_id)
+    sizer_scores = _filter_df_by_stage_view(sizer_scores, stage_view)
+    if sizer_scores.empty:
+        tprint("Policy optimiser stage filtering removed all sizer OOF rows.")
+        return {}
     strategy_rows: List[Dict[str, Any]] = []
     for selected in selected_candidates:
         key = next((k for k in meta_oofs.keys() if selected["strategy_id"] in k), None)
@@ -1871,6 +1935,7 @@ def run_policy_optimisation(
                     return {}
 
         outcomes = load_trade_outcomes(data_root, run_id, meta_oofs[key])
+        outcomes = _filter_df_by_stage_view(outcomes, stage_view)
         if outcomes.empty:
             continue
         outcomes = _attach_sizer_score(outcomes, sizer_scores, selected["strategy_id"])

--- a/extreme_price_movements/run_pipeline.py
+++ b/extreme_price_movements/run_pipeline.py
@@ -1338,6 +1338,23 @@ def run_all(cfg, ts_override=None):
     if ts_sig:
         tprint("STEP: POLICY OPTIMISER")
         try:
+            try:
+                slice_plan = load_or_build_slice_plan(
+                    cfg, ts_sig, force_refresh=cfg.get("refresh_slice_plan", False)
+                )
+                if "utility_policy_optimisation" in slice_plan.get(
+                    "materialized_views", {}
+                ):
+                    stage_view = slice_plan["materialized_views"][
+                        "utility_policy_optimisation"
+                    ]
+                    cfg["_active_stage_view"] = apply_stage_usage_limits(
+                        stage_view,
+                        max_assets=cfg.get("planned_max_assets"),
+                        max_months=cfg.get("planned_max_months"),
+                    )
+            except Exception as _slice_exc:
+                tprint(f"Policy optimiser slice plan loading failed: {_slice_exc}")
             run_id = ts_sig.strftime("%Y%m%d_%H%M%S")
             run_policy_optimisation(
                 data_root=cfg["data_root"],
@@ -1347,6 +1364,7 @@ def run_all(cfg, ts_override=None):
                     cfg.get("ridge_cost_pct", cfg.get("fee_bps", 50.0) / 10000.0)
                 ),
                 use_offset_optimiser=bool(cfg.get("run_limit_offset_optimiser", False)),
+                stage_view=cfg.get("_active_stage_view"),
             )
         except Exception as e:
             tprint(f"WARNING: Policy optimiser failed: {e}")
@@ -1917,6 +1935,23 @@ def main():
         ts_sig = _resolve_ts_sig(cfg, args.ts_override)
         if ts_sig:
             run_id = ts_sig.strftime("%Y%m%d_%H%M%S")
+            try:
+                slice_plan = load_or_build_slice_plan(
+                    cfg, ts_sig, force_refresh=cfg.get("refresh_slice_plan", False)
+                )
+                if "utility_policy_optimisation" in slice_plan.get(
+                    "materialized_views", {}
+                ):
+                    stage_view = slice_plan["materialized_views"][
+                        "utility_policy_optimisation"
+                    ]
+                    cfg["_active_stage_view"] = apply_stage_usage_limits(
+                        stage_view,
+                        max_assets=cfg.get("planned_max_assets"),
+                        max_months=cfg.get("planned_max_months"),
+                    )
+            except Exception as _slice_exc:
+                tprint(f"Policy optimiser slice plan loading failed: {_slice_exc}")
             tprint("STEP: POLICY OPTIMISER START (policy_optimiser.py)")
             run_policy_optimisation(
                 data_root=cfg["data_root"],
@@ -1926,6 +1961,7 @@ def main():
                     cfg.get("ridge_cost_pct", cfg.get("fee_bps", 50.0) / 10000.0)
                 ),
                 use_offset_optimiser=bool(cfg.get("run_limit_offset_optimiser", False)),
+                stage_view=cfg.get("_active_stage_view"),
             )
         else:
             tprint("ERROR: No feature directories found.")

--- a/extreme_price_movements/run_ridge_sizer.py
+++ b/extreme_price_movements/run_ridge_sizer.py
@@ -314,6 +314,10 @@ def load_base_oof_predictions(data_root: str, run_id: str) -> Dict[str, pd.DataF
                     else:
                         sigma_name = f"{col_name}_robust_sigma"
                     combined[sigma_name] = mdf["oof_sigma_robust"].values
+                tree_unc_cols = [c for c in mdf.columns if c.startswith("oof_tree_")]
+                for tc in tree_unc_cols:
+                    feat_name = tc.replace("oof_tree_", "")
+                    combined[f"{col_name}_{feat_name}"] = mdf[tc].values
 
         pair_roots = sorted(
             {

--- a/extreme_price_movements/slice_plan_store.py
+++ b/extreme_price_movements/slice_plan_store.py
@@ -239,7 +239,7 @@ def _assign_interleaved_week_periods(
         return
 
     shared_groups = [
-        ("train_base", "train_meta"),
+        ("train_base", "train_meta", "utility_policy_optimisation"),
     ]
 
     pool_for_stage: dict[str, str] = {}
@@ -368,11 +368,11 @@ def load_or_build_slice_plan(
         planner_config = SlicePlannerConfig.fast_defaults(schema=EventSchema())
 
     allocation_targets = {
-        "train_base": 0.55,
-        "train_meta": 0.55,
-        "sizer_train": 0.20,
-        "utility_policy_optimisation": 0.15,
-        "holdout_strategy_eval": 0.10
+        "train_base": 0.70,
+        "train_meta": 0.70,
+        "sizer_train": 0.25,
+        "utility_policy_optimisation": 0.70,
+        "holdout_strategy_eval": 0.05,
     }
 
     # Try to load existing

--- a/extreme_price_movements/training.py
+++ b/extreme_price_movements/training.py
@@ -7645,6 +7645,58 @@ def train_meta_models_from_artifacts(
                 return out
         return np.full(fallback_len, np.nan, dtype=np.float32)
 
+    _TREE_UNCERTAINTY_KEYS = (
+        "pred_mean",
+        "pred_std",
+        "pred_iqr",
+        "pred_cv",
+        "pred_std_robust",
+        "vote_entropy",
+        "vote_margin",
+        "vote_top_gap",
+        "leaf_support_mean",
+        "leaf_support_median",
+        "leaf_support_std",
+        "leaf_target_std_mean",
+        "leaf_target_iqr_mean",
+        "leaf_target_var_mean",
+        "leaf_centroid_dist_mean",
+        "leaf_centroid_dist_median",
+        "leaf_centroid_dist_cv",
+    )
+
+    def _collect_primary_tree_uncertainty_features(
+        strategy_id: str,
+        conf_local: dict[str, Any],
+        df_union: pd.DataFrame,
+        horizon_dfs_local: dict[int, tuple[pd.DataFrame, np.ndarray]],
+    ) -> pd.DataFrame:
+        out: dict[str, np.ndarray] = {}
+        models_by_h = (conf_local or {}).get("models_by_h", {}) if conf_local else {}
+        for h in sorted(horizon_dfs_local.keys()):
+            model_info = models_by_h.get(h) or {}
+            race = model_info.get("model")
+            if race is None:
+                continue
+            ds_h = horizon_dfs_local[h][0]
+            for feat_key in _TREE_UNCERTAINTY_KEYS:
+                vec_h = _race_sigma_vector(
+                    race, f"oof_tree_{feat_key}", len(ds_h)
+                )
+                aligned = _align_values_by_ts_symbol_keys(
+                    df_union["__ts__"].values,
+                    df_union["__symbol__"].values,
+                    ds_h["__ts__"].values,
+                    ds_h["__symbol__"].values,
+                    vec_h,
+                    fill_value=np.nan,
+                    dtype=np.float32,
+                )
+                out[f"pred_{strategy_id}_H{int(h)}_{feat_key}"] = aligned
+                out[f"pred_H{int(h)}_{feat_key}"] = aligned
+                out[f"base_H{int(h)}_{feat_key}"] = aligned
+        return pd.DataFrame(out, index=df_union.index) if out else pd.DataFrame(index=df_union.index)
+
     def _collect_wide_tight_variant_features(
         side: str,
         kind: str,
@@ -10434,6 +10486,14 @@ def train_meta_models_from_artifacts(
         )
         if not variant_feat_df.empty:
             X_feats = pd.concat([X_feats, variant_feat_df], axis=1)
+        else:
+            # Primary-only base training path: use within-ensemble uncertainty features
+            # from each horizon model so meta heads still receive dispersion signals.
+            primary_tree_feat_df = _collect_primary_tree_uncertainty_features(
+                k, conf, df, horizon_dfs
+            )
+            if not primary_tree_feat_df.empty:
+                X_feats = pd.concat([X_feats, primary_tree_feat_df], axis=1)
 
         # Disagreement features over this strategy's own horizon OOFs only.
         _diag_feats = {}
@@ -13432,12 +13492,12 @@ def train_models_from_artifacts(datasets, cfg, train_meta=True, train_base=True)
                     if hasattr(_race, "detailed_metrics")
                     else {}
                 )
-                for _sigma_key in ("oof_sigma_trees", "oof_sigma_robust"):
-                    _sigma_vals = _dm_best.get(_sigma_key)
-                    if _sigma_vals is not None and len(_sigma_vals) >= _n:
-                        _payload[_sigma_key] = np.asarray(
-                            _sigma_vals, dtype=np.float32
-                        )[:_n]
+                for _metric_key, _metric_vals in _dm_best.items():
+                    if _metric_key in ("oof_sigma_trees", "oof_sigma_robust") or _metric_key.startswith("oof_tree_"):
+                        if _metric_vals is not None and len(_metric_vals) >= _n:
+                            _payload[_metric_key] = np.asarray(
+                                _metric_vals, dtype=np.float32
+                            )[:_n]
 
                 if _df_oof is not None:
                     if "__ts__" in _df_oof.columns:
@@ -13585,12 +13645,12 @@ def train_models_from_artifacts(datasets, cfg, train_meta=True, train_base=True)
                             if hasattr(_race, "detailed_metrics")
                             else {}
                         )
-                        for _sigma_key in ("oof_sigma_trees", "oof_sigma_robust"):
-                            _sigma_vals = _dm_best.get(_sigma_key)
-                            if _sigma_vals is not None and len(_sigma_vals) >= _n:
-                                _payload[_sigma_key] = np.asarray(
-                                    _sigma_vals, dtype=np.float32
-                                )[:_n]
+                        for _metric_key, _metric_vals in _dm_best.items():
+                            if _metric_key in ("oof_sigma_trees", "oof_sigma_robust") or _metric_key.startswith("oof_tree_"):
+                                if _metric_vals is not None and len(_metric_vals) >= _n:
+                                    _payload[_metric_key] = np.asarray(
+                                        _metric_vals, dtype=np.float32
+                                    )[:_n]
                         if "__ts__" in _df_oof.columns:
                             _payload["timestamp"] = _normalize_oof_timestamps_to_numpy(
                                 _df_oof["__ts__"]


### PR DESCRIPTION
### Motivation
- Provide within-ensemble dispersion and leaf-local uncertainty features from tree-based base models so meta heads and downstream components can use richer uncertainty signals. 
- Allow pipeline stages (notably the policy optimiser and sizer) to be restricted by materialized slice views for safer / focused optimisation runs. 

### Description
- Extended `ModelRace` to compute many tree-uncertainty features (`_TREE_UNCERTAINTY_KEYS`) with new helpers `
  _build_leaf_context` and `_tree_uncertainty_features`, exposed via `predict_tree_uncertainty_features`, and persisted in the native sidecar as `best_model_leaf_context_` (file: `extreme_price_movements/model_race.py`).
- During training/OOF generation `ModelRace` now collects per-fold tree features into `detailed_metrics` and the stored metrics (`oof_tree_*` keys) and maps legacy `oof_sigma_trees` / `oof_sigma_robust` to the corresponding new features (file: `model_race.py`).
- Meta-training and artifact wiring were updated to surface these new tree uncertainty columns into meta features when wide/tight variant features are missing, and to emit `oof_tree_*` columns into saved OOF artifacts (file: `extreme_price_movements/training.py`).
- Consumers were updated to carry tree-uncertainty features downstream: `engine.py` now attaches per-horizon `pred_*_{feature}` and `base_*_{feature}` meta keys when base models implement `predict_tree_uncertainty_features`, `run_ridge_sizer.py` ingests `oof_tree_*` columns into the combined matrix, and `pipeline_steps.py`/`run_pipeline.py` propagate a computed slice `stage_view` into the policy optimiser (files: `engine.py`, `run_ridge_sizer.py`, `pipeline_steps.py`, `run_pipeline.py`).
- Added stage-view filtering utilities and integration: implemented `_filter_df_by_stage_view` and a `stage_view` parameter on `run_policy_optimisation` so `meta_oofs`, sizer scores, and outcome tables can be restricted by allowed symbols / time windows; added logic to load/build slice plans and apply `apply_stage_usage_limits` to set `cfg['_active_stage_view']` (files: `policy_optimiser.py`, `run_pipeline.py`, `pipeline_steps.py`).
- Adjusted slice planner defaults and shared-grouping to include `utility_policy_optimisation` and changed allocation target defaults in `slice_plan_store.py`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b6e66808832fae490cbc8a560d2f)