### PR TITLE
⚡ Bolt: [performance improvement] Replace slow iterrows in OCO policy evaluation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -47,3 +47,6 @@ Action: In feature injection (`pipeline_steps.py`), replace `pd.concat([df, pd.D
 ## 2025-04-16 - Replace pandas iterrows with numpy arrays
 Learning: `iterrows()` in pandas is extremely slow due to box/unbox overhead and index checking. Simple iteration is often better performed by converting dataframe columns to numpy arrays and using `zip()` to iterate, or vectorizing the operations entirely, especially inside inner loops for tasks like pruning dominance fronts or pairwise metrics processing.
 Action: Search for and replace `iterrows()` with vectorized alternatives or numpy iteration whenever optimizing loops in a DataFrame.
+## 2026-06-25 - Replace pandas iterrows with numpy array extraction and zip
+Learning: `iterrows()` inside inference monitoring loops, specifically `_evaluate_oco_policy` handling 5m bar evaluations, represents a major bottleneck because it instantiates a Pandas Series object for every single row, causing severe CPU overhead during rapid real-time monitoring.
+Action: Replace `iterrows()` loops with numpy array extraction (e.g. `bars["open"].to_numpy()`) and iterate using `zip()` over the arrays. This bypasses the Pandas object creation completely, maintaining exact functional equivalence but providing significant speedups in tight policy evaluation loops.

--- a/extreme_price_movements/inference/run_inference.py
+++ b/extreme_price_movements/inference/run_inference.py
@@ -1220,11 +1220,18 @@ def _evaluate_oco_policy(
         mfe_threshold = float(params.get("mfe_early_exit_threshold", 0.02))
         last_bar_ts = bars.index[-1]
 
-        for bar_ts, row in bars.iterrows():
-            bar_open = float(row["open"])
-            bar_high = float(row["high"])
-            bar_low = float(row["low"])
-            bar_close = float(row["close"])
+        # Use zip with numpy arrays instead of iterrows for performance
+        ts_arr = bars.index.to_numpy()
+        open_arr = bars["open"].to_numpy()
+        high_arr = bars["high"].to_numpy()
+        low_arr = bars["low"].to_numpy()
+        close_arr = bars["close"].to_numpy()
+
+        for bar_ts, bar_open, bar_high, bar_low, bar_close in zip(ts_arr, open_arr, high_arr, low_arr, close_arr):
+            bar_open = float(bar_open)
+            bar_high = float(bar_high)
+            bar_low = float(bar_low)
+            bar_close = float(bar_close)
 
             if side == "long":
                 mfe = max(mfe, (bar_high - entry_price) / max(entry_price, 1e-12))


### PR DESCRIPTION
💡 **What:**
Replaced the `iterrows()` loop in `_evaluate_oco_policy` (`extreme_price_movements/inference/run_inference.py`) with numpy array extraction and `zip()` iteration. Extracted `bars.index.to_numpy()` alongside data columns to maintain accurate variable unpacking.

🎯 **Why:**
`_evaluate_oco_policy` is a critical part of the inference evaluation loop that processes 5-minute OHLCV data. Calling `iterrows()` triggers the creation of a `pd.Series` object for every single row, causing severe CPU and memory bottlenecks when evaluated repeatedly across symbols. 

📊 **Impact:**
Bypasses Pandas object instantiation entirely, significantly reducing CPU cycles and accelerating real-time policy evaluation loops.

🔬 **Measurement:**
Unit tests validated that functionality and trigger logic are preserved exactly (`PYTHONPATH=. poetry run pytest extreme_price_movements/tests/test_inference_masking_and_oco.py`).

📓 **Journal:**
Added an entry to `.jules/bolt.md` recording this pattern.

---
*PR created automatically by Jules for task [4949891609949417674](https://jules.google.com/task/4949891609949417674) started by @remyroche*