### PR TITLE
Add EN-based uncertainty combiner and top-rank trade filtering; integrate into training & sizer

### DIFF
--- a/extreme_price_movements/en_based_uncertainty_features_selection.py
+++ b/extreme_price_movements/en_based_uncertainty_features_selection.py
@@ -1,0 +1,961 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import pickle
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import ElasticNet, LogisticRegression
+from sklearn.metrics import mean_absolute_error, mean_squared_error, roc_auc_score
+from sklearn.model_selection import StratifiedKFold
+
+try:
+    from extreme_price_movements.src_utils_tprint import tprint
+except Exception:
+    tprint = print
+
+ALPHA_GRID = (0.2, 0.5, 1.0, 2.0, 5.0, 10.0)
+L1_RATIO_GRID = (0.3, 0.4, 0.5, 0.6, 0.7, 0.8)
+
+
+@dataclass
+class FoldTransform:
+    lower: np.ndarray
+    upper: np.ndarray
+    mean: np.ndarray
+    std: np.ndarray
+
+
+@dataclass
+class CandidateResult:
+    alpha: float
+    l1_ratio: float
+    mean_j: float
+    std_j: float
+    mean_auc: float
+    mean_mono: float
+    mean_stab: float
+    fold_metrics: list[dict[str, float]]
+
+
+def _alpha_to_c(alpha: float) -> float:
+    """Map alpha->C for sklearn LogisticRegression.
+
+    Consistent mapping used everywhere in this module:
+    C = 1 / alpha
+    """
+    return 1.0 / max(float(alpha), 1e-12)
+
+
+def _logit(p: np.ndarray) -> np.ndarray:
+    p = np.clip(np.asarray(p, dtype=np.float32), 1e-4, 1 - 1e-4)
+    return np.log(p / (1.0 - p)).astype(np.float32)
+
+
+def _resolve_col(df: pd.DataFrame, candidates: list[str]) -> str | None:
+    for c in candidates:
+        if c in df.columns:
+            return c
+    return None
+
+
+def _assemble_raw_features(
+    df: pd.DataFrame, mode: str = "clf"
+) -> tuple[pd.DataFrame, str, str]:
+    base_col = _resolve_col(
+        df,
+        [
+            "oof_prob",
+            "oof_pred",
+            "pred",
+            "base",
+            "base_H2",
+            "base_H4",
+            "p_final_oof",
+        ],
+    )
+    if base_col is None:
+        raise ValueError("No base prediction column found.")
+    if str(mode).lower() == "reg":
+        y_col = _resolve_col(df, ["y_ret", "__y_ret__", "return", "target_reg"])
+    else:
+        y_col = _resolve_col(df, ["y_bin", "label", "target", "y_true"])
+    if y_col is None:
+        if str(mode).lower() == "reg":
+            raise ValueError(
+                "No regression target found (expected y_ret/__y_ret__/return/target_reg)."
+            )
+        raise ValueError(
+            "No binary label column found (expected y_bin/label/target/y_true)."
+        )
+
+    raw = pd.DataFrame(index=df.index)
+    base_prob = np.asarray(df[base_col].values, dtype=np.float32)
+    raw["base_pred"] = base_prob
+    raw["base_logit"] = _logit(base_prob)
+    raw["abs_base_logit"] = np.abs(raw["base_logit"].values).astype(np.float32)
+
+    col_map = {
+        "pred_std_robust": ["oof_sigma_robust", "robust_sigma", "pred_std_robust"],
+        "vote_entropy": ["oof_tree_vote_entropy", "vote_entropy"],
+        "leaf_support_q25": ["oof_tree_leaf_support_q25", "leaf_support_q25"],
+        "leaf_target_std_mean": [
+            "oof_tree_leaf_target_std_mean",
+            "leaf_target_std_mean",
+            "oof_tree_leaf_target_iqr_mean",
+            "leaf_target_iqr_mean",
+        ],
+        "leaf_centroid_dist_mean": [
+            "oof_tree_leaf_centroid_dist_mean",
+            "leaf_centroid_dist_mean",
+        ],
+        "leaf_centroid_dist_cv": [
+            "oof_tree_leaf_centroid_dist_cv",
+            "leaf_centroid_dist_cv",
+        ],
+        "vote_margin": ["oof_tree_vote_margin", "vote_margin"],
+        "vote_top_gap": ["oof_tree_vote_top_gap", "vote_top_gap"],
+    }
+    for k, cand in col_map.items():
+        c = _resolve_col(df, cand)
+        if c is not None:
+            raw[k] = pd.to_numeric(df[c], errors="coerce").astype(np.float32)
+
+    # uncertainty direction unification
+    for maybe_flip in ["vote_margin", "vote_top_gap", "leaf_support_q25"]:
+        if maybe_flip in raw.columns:
+            raw[maybe_flip] = -raw[maybe_flip].values
+
+    if "pred_std_robust" not in raw.columns:
+        raw["pred_std_robust"] = np.abs(raw["base_logit"].values) * 0.0
+    if "vote_entropy" not in raw.columns:
+        raw["vote_entropy"] = np.abs(raw["base_logit"].values) * 0.0
+    if "leaf_support_q25" not in raw.columns:
+        raw["leaf_support_q25"] = np.abs(raw["base_logit"].values) * 0.0
+    if "leaf_target_std_mean" not in raw.columns:
+        raw["leaf_target_std_mean"] = np.abs(raw["base_logit"].values) * 0.0
+    if "leaf_centroid_dist_mean" not in raw.columns:
+        raw["leaf_centroid_dist_mean"] = np.abs(raw["base_logit"].values) * 0.0
+    if "leaf_centroid_dist_cv" not in raw.columns:
+        raw["leaf_centroid_dist_cv"] = np.abs(raw["base_logit"].values) * 0.0
+
+    raw["distance_x_low_support"] = (
+        raw["leaf_centroid_dist_mean"] * raw["leaf_support_q25"]
+    )
+    raw["distance_x_leaf_target_std"] = (
+        raw["leaf_centroid_dist_mean"] * raw["leaf_target_std_mean"]
+    )
+    raw["disagreement_x_low_support"] = raw["vote_entropy"] * raw["leaf_support_q25"]
+    raw["disagreement_x_distance"] = (
+        raw["vote_entropy"] * raw["leaf_centroid_dist_mean"]
+    )
+    raw["abs_base_logit_x_disagreement"] = raw["abs_base_logit"] * raw["vote_entropy"]
+    raw["abs_base_logit_x_low_support"] = (
+        raw["abs_base_logit"] * raw["leaf_support_q25"]
+    )
+    raw["abs_base_logit_x_distance"] = (
+        raw["abs_base_logit"] * raw["leaf_centroid_dist_mean"]
+    )
+
+    return raw, base_col, y_col
+
+
+def _fit_transform_fold(
+    X_tr: np.ndarray, X_va: np.ndarray
+) -> tuple[np.ndarray, np.ndarray, FoldTransform]:
+    lo = np.nanpercentile(X_tr, 1.0, axis=0)
+    hi = np.nanpercentile(X_tr, 99.0, axis=0)
+    X_tr_w = np.clip(X_tr, lo, hi)
+    X_va_w = np.clip(X_va, lo, hi)
+    mu = np.nanmean(X_tr_w, axis=0)
+    sd = np.nanstd(X_tr_w, axis=0)
+    sd = np.where(sd < 1e-6, 1.0, sd)
+    X_tr_z = (X_tr_w - mu) / sd
+    X_va_z = (X_va_w - mu) / sd
+    X_tr_z = np.nan_to_num(X_tr_z, nan=0.0, posinf=0.0, neginf=0.0)
+    X_va_z = np.nan_to_num(X_va_z, nan=0.0, posinf=0.0, neginf=0.0)
+    return (
+        X_tr_z.astype(np.float32),
+        X_va_z.astype(np.float32),
+        FoldTransform(lo, hi, mu, sd),
+    )
+
+
+def _mono_top3(y: np.ndarray, p: np.ndarray) -> float:
+    if len(y) < 20:
+        return 0.0
+    order = np.argsort(-p)
+    y_ord = y[order]
+    bins = np.array_split(y_ord, 10)
+    r = [float(np.mean(b >= 0.5)) if len(b) else 0.0 for b in bins[:3]]
+    r1, r2, r3 = r
+    return float((r1 - r3) - max(0.0, r2 - r1) - max(0.0, r3 - r2))
+
+
+def _brier(y: np.ndarray, p: np.ndarray) -> float:
+    p = np.clip(np.asarray(p, dtype=float), 1e-6, 1 - 1e-6)
+    y = np.asarray(y, dtype=float)
+    return float(np.mean((p - y) ** 2))
+
+
+def _ece(y: np.ndarray, p: np.ndarray, n_bins: int = 10) -> float:
+    y = np.asarray(y, dtype=float)
+    p = np.clip(np.asarray(p, dtype=float), 1e-6, 1 - 1e-6)
+    bins = np.linspace(0.0, 1.0, n_bins + 1)
+    ece = 0.0
+    for i in range(n_bins):
+        if i < n_bins - 1:
+            m = (p >= bins[i]) & (p < bins[i + 1])
+        else:
+            m = (p >= bins[i]) & (p <= bins[i + 1])
+        if not np.any(m):
+            continue
+        ece += float(np.mean(m)) * abs(float(np.mean(p[m]) - np.mean(y[m])))
+    return float(ece)
+
+
+def _rank_ic(y: np.ndarray, p: np.ndarray) -> float:
+    yv = np.asarray(y, dtype=float)
+    pv = np.asarray(p, dtype=float)
+    if len(yv) < 5:
+        return 0.0
+    ry = pd.Series(yv).rank(pct=True).values
+    rp = pd.Series(pv).rank(pct=True).values
+    return (
+        float(np.corrcoef(ry, rp)[0, 1])
+        if np.isfinite(np.corrcoef(ry, rp)[0, 1])
+        else 0.0
+    )
+
+
+def _top_slice_metrics(
+    y: np.ndarray, p: np.ndarray, frac: float = 0.30
+) -> dict[str, float]:
+    y = np.asarray(y, dtype=float)
+    p = np.asarray(p, dtype=float)
+    n = len(y)
+    k = max(1, int(np.ceil(frac * n)))
+    idx = np.argsort(-p)[:k]
+    y_top = y[idx]
+    y_all = y
+    hit_top = float(np.mean(y_top >= 0.5))
+    hit_all = float(np.mean(y_all >= 0.5))
+    lift = hit_top / max(hit_all, 1e-6)
+    ic = _rank_ic(y_top, p[idx])
+    # chunked IC std as stability proxy
+    chunks = np.array_split(np.arange(len(idx)), min(5, len(idx)))
+    chunk_ics = []
+    for c in chunks:
+        if len(c) < 3:
+            continue
+        chunk_ics.append(_rank_ic(y_top[c], p[idx][c]))
+    ic_std = float(np.std(chunk_ics)) if chunk_ics else 0.0
+    stability = float(ic - 0.5 * ic_std)
+    # top decile hit rate std
+    order = np.argsort(-p)
+    decs = np.array_split(order, 10)
+    d_hits = [float(np.mean(y[d] >= 0.5)) if len(d) else 0.0 for d in decs]
+    mono = _mono_top3(y, p)
+    td_std = float(np.std(d_hits[:1] if len(d_hits) == 1 else d_hits[:2]))
+    ece_top30 = _ece(y_top, np.clip(p[idx], 1e-6, 1 - 1e-6))
+    return {
+        "lift_top30": lift,
+        "ic_top30": ic,
+        "ic_top30_std": ic_std,
+        "stability_top30": stability,
+        "decile_monotonicity": mono,
+        "top_decile_hit_rate_std": td_std,
+        "ece_top30": ece_top30,
+    }
+
+
+def _global_metrics(y: np.ndarray, p: np.ndarray) -> dict[str, float]:
+    auc = float(roc_auc_score(y, p)) if len(np.unique(y)) > 1 else 0.5
+    brier = _brier(y, p)
+    top = _top_slice_metrics(y, p, frac=0.30)
+    return {
+        "auc": auc,
+        "auc_over_random": auc / 0.5,
+        "brier": brier,
+        **top,
+    }
+
+
+def _global_metrics_reg(y: np.ndarray, pred: np.ndarray) -> dict[str, float]:
+    yv = np.asarray(y, dtype=float)
+    pv = np.asarray(pred, dtype=float)
+    rmse = float(np.sqrt(mean_squared_error(yv, pv))) if len(yv) else 0.0
+    mae = float(mean_absolute_error(yv, pv)) if len(yv) else 0.0
+    ic = _rank_ic(yv, pv)
+    top = _top_slice_metrics((yv > np.nanmedian(yv)).astype(float), pv, frac=0.30)
+    return {
+        "rmse": rmse,
+        "mae": mae,
+        "ic_global": ic,
+        **top,
+    }
+
+
+def _evaluate_candidate(
+    y: np.ndarray,
+    folds: list[tuple[np.ndarray, np.ndarray]],
+    fold_cache: dict[int, tuple[np.ndarray, np.ndarray]],
+    alpha: float,
+    l1_ratio: float,
+    mode: str = "clf",
+) -> CandidateResult:
+    fold_vals: list[dict[str, float]] = []
+    js: list[float] = []
+    monos: list[float] = []
+    aucs: list[float] = []
+    for i, (tr, va) in enumerate(folds):
+        X_tr, X_va = fold_cache[i]
+        y_tr = y[tr]
+        y_va = y[va]
+        if str(mode).lower() == "reg":
+            model = ElasticNet(
+                alpha=float(alpha),
+                l1_ratio=float(l1_ratio),
+                fit_intercept=True,
+                max_iter=8000,
+                random_state=42,
+            )
+            model.fit(X_tr, y_tr)
+            p = model.predict(X_va)
+            mono = _mono_top3((y_va > np.nanmedian(y_va)).astype(float), p)
+            auc = _rank_ic(y_va, p)
+        else:
+            model = LogisticRegression(
+                penalty="elasticnet",
+                solver="saga",
+                fit_intercept=True,
+                max_iter=8000,
+                C=_alpha_to_c(alpha),
+                l1_ratio=float(l1_ratio),
+                random_state=42,
+            )
+            model.fit(X_tr, y_tr)
+            p = model.predict_proba(X_va)[:, 1]
+            mono = _mono_top3(y_va, p)
+            auc = float(roc_auc_score(y_va, p)) if len(np.unique(y_va)) > 1 else 0.5
+        monos.append(mono)
+        aucs.append(auc)
+        fold_vals.append({"mono_top3": mono, "auc": auc})
+    mean_mono = float(np.mean(monos))
+    std_mono = float(np.std(monos))
+    m_stab = float(mean_mono - 0.5 * std_mono)
+    mean_auc = float(np.mean(aucs))
+    # J = 0.65 * M_mono_top3 + 0.10 * M_stab_top3 + 0.25 * AUC
+    j = float(0.65 * mean_mono + 0.10 * m_stab + 0.25 * mean_auc)
+    js = [j]
+    return CandidateResult(
+        alpha=float(alpha),
+        l1_ratio=float(l1_ratio),
+        mean_j=float(np.mean(js)),
+        std_j=0.0,
+        mean_auc=mean_auc,
+        mean_mono=mean_mono,
+        mean_stab=m_stab,
+        fold_metrics=fold_vals,
+    )
+
+
+def _stage_a_prune(
+    X_raw: pd.DataFrame,
+    y: np.ndarray,
+    feature_names: list[str],
+    coef_active_threshold: float = 0.01,
+    mode: str = "clf",
+) -> tuple[list[str], list[dict[str, Any]]]:
+    hist: list[dict[str, Any]] = []
+    current = list(feature_names)
+    n0 = len(current)
+    floor_keep = int(math.ceil(0.70 * n0))
+    skf = StratifiedKFold(n_splits=2, shuffle=True, random_state=42)
+    folds = list(skf.split(X_raw.values, y))
+
+    round_idx = 0
+    while True:
+        round_idx += 1
+        # cache transformed matrices by fold
+        fold_cache: dict[int, tuple[np.ndarray, np.ndarray]] = {}
+        for i, (tr, va) in enumerate(folds):
+            X_tr = X_raw.iloc[tr][current].to_numpy(dtype=np.float32)
+            X_va = X_raw.iloc[va][current].to_numpy(dtype=np.float32)
+            X_tr_z, X_va_z, _ = _fit_transform_fold(X_tr, X_va)
+            fold_cache[i] = (X_tr_z, X_va_z)
+
+        cand_results: list[CandidateResult] = []
+        for alpha in ALPHA_GRID:
+            for l1 in L1_RATIO_GRID:
+                cand_results.append(
+                    _evaluate_candidate(y, folds, fold_cache, alpha, l1, mode=mode)
+                )
+
+        scores = np.array([c.mean_j for c in cand_results], dtype=float)
+        best_idx = int(np.argmax(scores))
+        best_score = float(scores[best_idx])
+        se = float(np.std(scores) / max(math.sqrt(len(scores)), 1.0))
+        contenders = [c for c in cand_results if c.mean_j >= best_score - se]
+
+        feat_stats = {
+            f: {"active": 0, "total": 0, "pos": 0, "neg": 0, "coef_abs": []}
+            for f in current
+        }
+        for c in contenders:
+            for tr, va in folds:
+                X_tr = X_raw.iloc[tr][current].to_numpy(dtype=np.float32)
+                X_va = X_raw.iloc[va][current].to_numpy(dtype=np.float32)
+                X_tr_z, _, _ = _fit_transform_fold(X_tr, X_va)
+                if str(mode).lower() == "reg":
+                    model = ElasticNet(
+                        alpha=float(c.alpha),
+                        l1_ratio=float(c.l1_ratio),
+                        fit_intercept=True,
+                        max_iter=8000,
+                        random_state=42,
+                    )
+                else:
+                    model = LogisticRegression(
+                        penalty="elasticnet",
+                        solver="saga",
+                        fit_intercept=True,
+                        max_iter=8000,
+                        C=_alpha_to_c(c.alpha),
+                        l1_ratio=float(c.l1_ratio),
+                        random_state=42,
+                    )
+                model.fit(X_tr_z, y[tr])
+                coef = model.coef_.reshape(-1)
+                for j, f in enumerate(current):
+                    v = float(coef[j])
+                    abs_v = abs(v)
+                    feat_stats[f]["total"] += 1
+                    if abs_v > coef_active_threshold:
+                        feat_stats[f]["active"] += 1
+                        feat_stats[f]["coef_abs"].append(abs_v)
+                        if v >= 0:
+                            feat_stats[f]["pos"] += 1
+                        else:
+                            feat_stats[f]["neg"] += 1
+
+        keep = []
+        dropped = []
+        for f in current:
+            st = feat_stats[f]
+            tot = max(int(st["total"]), 1)
+            freq = float(st["active"]) / tot
+            sign_cons = float(max(st["pos"], st["neg"])) / max(int(st["active"]), 1)
+            med_abs = float(np.median(st["coef_abs"])) if st["coef_abs"] else 0.0
+            if freq >= 0.70 and sign_cons >= 0.80:
+                keep.append(f)
+            else:
+                dropped.append((f, freq, sign_cons, med_abs))
+
+        if len(keep) < floor_keep:
+            need = floor_keep - len(keep)
+            dropped_sorted = sorted(
+                dropped,
+                key=lambda x: x[1] * x[2] * x[3],
+                reverse=True,
+            )
+            keep.extend([f for f, *_ in dropped_sorted[:need]])
+
+        keep = list(dict.fromkeys(keep))
+        removed = [f for f in current if f not in keep]
+        hist.append(
+            {
+                "round": round_idx,
+                "n_features": len(current),
+                "n_keep": len(keep),
+                "n_removed": len(removed),
+                "best_mean_j": best_score,
+                "se": se,
+            }
+        )
+        if len(removed) <= 1:
+            break
+        current = keep
+
+    return current, hist
+
+
+def _fit_5fold_oof(
+    X_raw: pd.DataFrame,
+    y: np.ndarray,
+    features: list[str],
+    alpha: float,
+    l1_ratio: float,
+    mode: str = "clf",
+) -> tuple[np.ndarray, np.ndarray, list[dict[str, Any]], dict[str, Any]]:
+    skf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
+    oof_s = np.full(len(X_raw), np.nan, dtype=np.float32)
+    oof_p = np.full(len(X_raw), np.nan, dtype=np.float32)
+    fold_transforms: list[dict[str, Any]] = []
+    for fold_i, (tr, va) in enumerate(skf.split(X_raw.values, y)):
+        X_tr = X_raw.iloc[tr][features].to_numpy(dtype=np.float32)
+        X_va = X_raw.iloc[va][features].to_numpy(dtype=np.float32)
+        X_tr_z, X_va_z, tf = _fit_transform_fold(X_tr, X_va)
+        if str(mode).lower() == "reg":
+            model = ElasticNet(
+                alpha=float(alpha),
+                l1_ratio=float(l1_ratio),
+                fit_intercept=True,
+                max_iter=10000,
+                random_state=42,
+            )
+        else:
+            model = LogisticRegression(
+                penalty="elasticnet",
+                solver="saga",
+                fit_intercept=True,
+                max_iter=10000,
+                C=_alpha_to_c(alpha),
+                l1_ratio=float(l1_ratio),
+                random_state=42,
+            )
+        model.fit(X_tr_z, y[tr])
+        if str(mode).lower() == "reg":
+            pred = model.predict(X_va_z).astype(np.float32)
+            oof_s[va] = pred
+            oof_p[va] = pred
+        else:
+            oof_s[va] = model.decision_function(X_va_z).astype(np.float32)
+            oof_p[va] = model.predict_proba(X_va_z)[:, 1].astype(np.float32)
+        fold_transforms.append(
+            {
+                "fold": int(fold_i),
+                "lower": tf.lower.tolist(),
+                "upper": tf.upper.tolist(),
+                "mean": tf.mean.tolist(),
+                "std": tf.std.tolist(),
+            }
+        )
+
+    X_full = X_raw[features].to_numpy(dtype=np.float32)
+    Xf_w = np.clip(
+        X_full,
+        np.nanpercentile(X_full, 1, axis=0),
+        np.nanpercentile(X_full, 99, axis=0),
+    )
+    mu = np.nanmean(Xf_w, axis=0)
+    sd = np.where(np.nanstd(Xf_w, axis=0) < 1e-6, 1.0, np.nanstd(Xf_w, axis=0))
+    Xf_z = np.nan_to_num((Xf_w - mu) / sd, nan=0.0, posinf=0.0, neginf=0.0)
+    if str(mode).lower() == "reg":
+        final_model = ElasticNet(
+            alpha=float(alpha),
+            l1_ratio=float(l1_ratio),
+            fit_intercept=True,
+            max_iter=12000,
+            random_state=42,
+        )
+    else:
+        final_model = LogisticRegression(
+            penalty="elasticnet",
+            solver="saga",
+            fit_intercept=True,
+            max_iter=12000,
+            C=_alpha_to_c(alpha),
+            l1_ratio=float(l1_ratio),
+            random_state=42,
+        )
+    final_model.fit(Xf_z, y)
+    final_bundle = {
+        "features": features,
+        "lower": np.nanpercentile(X_full, 1, axis=0).tolist(),
+        "upper": np.nanpercentile(X_full, 99, axis=0).tolist(),
+        "mean": mu.tolist(),
+        "std": sd.tolist(),
+        "model": final_model,
+        "alpha": float(alpha),
+        "l1_ratio": float(l1_ratio),
+        "C": float(_alpha_to_c(alpha)),
+        "mode": str(mode).lower(),
+    }
+    return oof_s, oof_p, fold_transforms, final_bundle
+
+
+def run_en_uncertainty_combiner(
+    df: pd.DataFrame,
+    *,
+    coef_active_threshold: float = 0.01,
+    min_improvement: float = 0.0,
+    mode: str = "clf",
+) -> dict[str, Any]:
+    tprint(
+        "[en_uncertainty] start run_en_uncertainty_combiner "
+        f"rows={len(df)} coef_active_threshold={coef_active_threshold:.4f} "
+        f"min_improvement={min_improvement:.4f}"
+    )
+    mode = str(mode).lower()
+    raw, base_col, y_col = _assemble_raw_features(df, mode=mode)
+    y = np.asarray(df[y_col].values, dtype=np.float32)
+    valid = np.isfinite(y)
+    y = y[valid]
+    raw = raw.loc[valid].reset_index(drop=True)
+    if mode == "clf":
+        y = (y >= 0.5).astype(np.int8)
+    tprint(
+        f"[en_uncertainty] valid rows={len(y)} base_col={base_col} y_col={y_col} "
+        f"raw_features={len(raw.columns)}"
+    )
+
+    base_pred = np.asarray(raw["base_pred"].values, dtype=float)
+    if mode == "clf":
+        base_auc = float(roc_auc_score(y, base_pred)) if len(np.unique(y)) > 1 else 0.5
+        base_mono = _mono_top3(y, base_pred)
+        base_stab = base_mono
+        base_j = float(0.65 * base_mono + 0.10 * base_stab + 0.25 * base_auc)
+        base_global = _global_metrics(y, np.clip(base_pred, 1e-6, 1 - 1e-6))
+    else:
+        base_auc = _rank_ic(y, base_pred)
+        base_mono = _mono_top3((y > np.nanmedian(y)).astype(float), base_pred)
+        base_stab = float(base_mono)
+        base_j = float(0.65 * base_mono + 0.10 * base_stab + 0.25 * base_auc)
+        base_global = _global_metrics_reg(y, base_pred)
+    tprint(
+        "[en_uncertainty] BEFORE "
+        f"mode={mode} "
+        f"AUC={base_global.get('auc', base_global.get('ic_global', 0.0)):.4f} "
+        f"AUC/Random={base_global.get('auc_over_random', 1.0):.3f} "
+        f"Brier={base_global.get('brier', np.nan):.5f} Lift@30={base_global['lift_top30']:.4f} "
+        f"IC@30={base_global['ic_top30']:.4f} ICstd@30={base_global['ic_top30_std']:.4f} "
+        f"Stab@30={base_global['stability_top30']:.4f} Mono={base_global['decile_monotonicity']:.4f} "
+        f"TopDecHitStd={base_global['top_decile_hit_rate_std']:.4f} ECE_top30={base_global['ece_top30']:.4f}"
+    )
+
+    feature_names = [c for c in raw.columns if c not in {"base_pred"}]
+    reduced, pruning_hist = _stage_a_prune(
+        raw, y, feature_names, coef_active_threshold=coef_active_threshold, mode=mode
+    )
+    tprint(
+        f"[en_uncertainty] stage-a done: features {len(feature_names)} -> {len(reduced)} rounds={len(pruning_hist)}"
+    )
+
+    skf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
+    folds = list(skf.split(raw.values, y))
+    fold_cache: dict[int, tuple[np.ndarray, np.ndarray]] = {}
+    for i, (tr, va) in enumerate(folds):
+        X_tr = raw.iloc[tr][reduced].to_numpy(dtype=np.float32)
+        X_va = raw.iloc[va][reduced].to_numpy(dtype=np.float32)
+        fold_cache[i] = _fit_transform_fold(X_tr, X_va)[:2]
+
+    results: list[CandidateResult] = []
+    for alpha in ALPHA_GRID:
+        for l1 in L1_RATIO_GRID:
+            results.append(
+                _evaluate_candidate(y, folds, fold_cache, alpha, l1, mode=mode)
+            )
+
+    scores = np.array([r.mean_j for r in results], dtype=float)
+    best_idx = int(np.argmax(scores))
+    best_score = float(scores[best_idx])
+    se = float(np.std(scores) / max(math.sqrt(len(scores)), 1.0))
+    contenders = [r for r in results if r.mean_j >= best_score - se]
+
+    def _model_size(cols: list[str]) -> int:
+        inter = sum(1 for c in cols if "_x_" in c)
+        main = len(cols) - inter
+        return int(main + 2 * inter)
+
+    contenders = sorted(
+        contenders,
+        key=lambda r: (
+            _model_size(reduced),
+            -r.mean_j,
+            -r.mean_mono,
+            -r.mean_auc,
+        ),
+    )
+    chosen = contenders[0] if contenders else results[best_idx]
+    tprint(
+        "[en_uncertainty] stage-b chosen "
+        f"alpha={chosen.alpha:.4f} l1_ratio={chosen.l1_ratio:.4f} "
+        f"mean_J={chosen.mean_j:.5f} mono={chosen.mean_mono:.5f} auc={chosen.mean_auc:.5f}"
+    )
+
+    guard_monotonic = chosen.mean_mono >= base_mono
+    guard_stability = chosen.mean_stab >= base_stab
+    guard_j = chosen.mean_j >= base_j + float(min_improvement)
+    improved = bool(guard_j and guard_monotonic and guard_stability)
+    tprint(
+        "[en_uncertainty] guardrails "
+        f"J={guard_j} mono={guard_monotonic} stability={guard_stability} "
+        f"-> improved={improved}"
+    )
+    if improved:
+        s_oof, p_oof, fold_tf, final_bundle = _fit_5fold_oof(
+            raw, y, reduced, chosen.alpha, chosen.l1_ratio, mode=mode
+        )
+    else:
+        if mode == "clf":
+            s_oof = _logit(raw["base_pred"].values)
+            p_oof = np.asarray(raw["base_pred"].values, dtype=np.float32)
+        else:
+            s_oof = np.asarray(raw["base_pred"].values, dtype=np.float32)
+            p_oof = np.asarray(raw["base_pred"].values, dtype=np.float32)
+        fold_tf = []
+        final_bundle = {}
+
+    out_df = pd.DataFrame(index=np.flatnonzero(valid))
+    out_df["s_final_oof"] = s_oof
+    if mode == "clf":
+        out_df["p_final_oof"] = p_oof
+        final_global = _global_metrics(y, np.clip(p_oof, 1e-6, 1 - 1e-6))
+    else:
+        out_df["yhat_final_oof"] = p_oof
+        final_global = _global_metrics_reg(y, p_oof)
+    rank_corr = _rank_ic(base_pred, p_oof)
+    base_top_dec = np.zeros(len(y), dtype=bool)
+    final_top_dec = np.zeros(len(y), dtype=bool)
+    k10 = max(1, int(np.ceil(0.10 * len(y))))
+    base_top_dec[np.argsort(-base_pred)[:k10]] = True
+    final_top_dec[np.argsort(-p_oof)[:k10]] = True
+    entering = float(np.mean((~base_top_dec) & final_top_dec))
+    leaving = float(np.mean(base_top_dec & (~final_top_dec)))
+    tprint(
+        "[en_uncertainty] AFTER "
+        f"mode={mode} "
+        f"AUC={final_global.get('auc', final_global.get('ic_global', 0.0)):.4f} "
+        f"AUC/Random={final_global.get('auc_over_random', 1.0):.3f} "
+        f"Brier={final_global.get('brier', np.nan):.5f} Lift@30={final_global['lift_top30']:.4f} "
+        f"IC@30={final_global['ic_top30']:.4f} ICstd@30={final_global['ic_top30_std']:.4f} "
+        f"Stab@30={final_global['stability_top30']:.4f} Mono={final_global['decile_monotonicity']:.4f} "
+        f"TopDecHitStd={final_global['top_decile_hit_rate_std']:.4f} ECE_top30={final_global['ece_top30']:.4f} "
+        f"Spearman(base,final)={rank_corr:.4f} EnterTop10={entering:.4f} LeaveTop10={leaving:.4f}"
+    )
+
+    return {
+        "base_col": base_col,
+        "label_col": y_col,
+        "raw_feature_table": raw,
+        "selected_features": reduced,
+        "selected_hyperparams": {
+            "alpha": float(chosen.alpha),
+            "l1_ratio": float(chosen.l1_ratio),
+            "C": float(_alpha_to_c(chosen.alpha)),
+            "mode": mode,
+        },
+        "pruning_history": pruning_hist,
+        "candidate_metrics": [r.__dict__ for r in results],
+        "comparison": {
+            "base_j": base_j,
+            "base_mono": base_mono,
+            "base_auc": base_auc,
+            "final_j": float(chosen.mean_j),
+            "final_mono": float(chosen.mean_mono),
+            "final_auc": float(chosen.mean_auc),
+            "improved": improved,
+            "guardrails": {
+                "j": bool(guard_j),
+                "monotonicity": bool(guard_monotonic),
+                "stability": bool(guard_stability),
+            },
+            "before_global": base_global,
+            "after_global": final_global,
+            "spearman_base_final": float(rank_corr),
+            "boundary_migration": {
+                "pct_entering_top_decile": entering,
+                "pct_leaving_top_decile": leaving,
+            },
+        },
+        "oof_outputs": out_df,
+        "fold_transforms": fold_tf,
+        "final_model_bundle": final_bundle,
+    }
+
+
+def run_on_artifacts(data_root: str, run_id: str) -> dict[str, Any]:
+    oof_dir = Path(data_root) / "artifacts" / run_id / "oof"
+    labels_dir = Path(data_root) / "artifacts" / run_id / "labels"
+    out_dir = Path(data_root) / "artifacts" / run_id / "en_uncertainty"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    summary = {"processed": [], "skipped": []}
+    tprint(
+        f"[en_uncertainty] run_on_artifacts start: run_id={run_id} oof_dir={oof_dir}"
+    )
+
+    def _load_label_frame_for_oof(stem: str) -> pd.DataFrame | None:
+        # oof_{strategy}_H{h} -> train_{strategy}_{h}
+        m = re.match(r"^oof_(.+)_H(\d+)$", stem)
+        if not m:
+            return None
+        strategy_id = m.group(1)
+        horizon = int(m.group(2))
+        label_path = labels_dir / f"train_{strategy_id}_{horizon}.parquet"
+        if not label_path.exists():
+            return None
+        try:
+            return pd.read_parquet(label_path)
+        except Exception:
+            return None
+
+    def _attach_target_if_missing(
+        df: pd.DataFrame, stem: str, mode: str
+    ) -> pd.DataFrame:
+        if mode == "reg":
+            if any(
+                c in df.columns for c in ["y_ret", "__y_ret__", "return", "target_reg"]
+            ):
+                return df
+        elif "y_bin" in df.columns:
+            return df
+        label_df = _load_label_frame_for_oof(stem)
+        if label_df is None:
+            return df
+        out = df.copy()
+        if mode == "reg":
+            if "__y_ret__" in label_df.columns:
+                yv = np.asarray(label_df["__y_ret__"].values, dtype=np.float32)
+                t_col = "y_ret"
+            elif "y_ret" in label_df.columns:
+                yv = np.asarray(label_df["y_ret"].values, dtype=np.float32)
+                t_col = "y_ret"
+            elif "return" in label_df.columns:
+                yv = np.asarray(label_df["return"].values, dtype=np.float32)
+                t_col = "y_ret"
+            else:
+                return df
+        else:
+            if "__y_bin__" in label_df.columns:
+                yv = np.asarray(label_df["__y_bin__"].values, dtype=np.float32)
+            elif "y_bin" in label_df.columns:
+                yv = np.asarray(label_df["y_bin"].values, dtype=np.float32)
+            else:
+                return df
+            t_col = "y_bin"
+        n = min(len(out), len(yv))
+        out[t_col] = np.nan
+        if n > 0:
+            out.loc[: n - 1, t_col] = yv[:n]
+        return out
+
+    for p in sorted(oof_dir.glob("oof_*.parquet")):
+        try:
+            df = pd.read_parquet(p)
+            _mode = (
+                "clf"
+                if "oof_prob" in df.columns
+                else ("reg" if "oof_pred" in df.columns else "skip")
+            )
+            if _mode == "skip":
+                summary["skipped"].append(
+                    {"file": p.name, "reason": "not_supported_oof"}
+                )
+                continue
+            df = _attach_target_if_missing(df, p.stem, _mode)
+            if _mode == "clf" and "y_bin" not in df.columns:
+                summary["skipped"].append(
+                    {"file": p.name, "reason": "missing_y_bin", "mode": _mode}
+                )
+                continue
+            if _mode == "reg" and not any(
+                c in df.columns for c in ["y_ret", "__y_ret__", "return", "target_reg"]
+            ):
+                summary["skipped"].append(
+                    {"file": p.name, "reason": "missing_y_ret", "mode": _mode}
+                )
+                continue
+            res = run_en_uncertainty_combiner(df, mode=_mode)
+            oof_cols = res["oof_outputs"]
+            df2 = df.copy()
+            df2.loc[oof_cols.index, "s_final_oof"] = oof_cols["s_final_oof"].values
+            if "p_final_oof" in oof_cols.columns:
+                df2.loc[oof_cols.index, "p_final_oof"] = oof_cols["p_final_oof"].values
+            if "yhat_final_oof" in oof_cols.columns:
+                df2.loc[oof_cols.index, "yhat_final_oof"] = oof_cols[
+                    "yhat_final_oof"
+                ].values
+            for c in ["base_logit", "abs_base_logit"]:
+                if c in res["raw_feature_table"].columns:
+                    df2.loc[oof_cols.index, c] = res["raw_feature_table"][c].values
+            df2.to_parquet(p, index=False)
+
+            stem = p.stem.replace("oof_", "")
+            metrics_path = out_dir / f"{stem}_metrics.json"
+            model_path = out_dir / f"{stem}_model.pkl"
+            with open(metrics_path, "w", encoding="utf-8") as f:
+                json.dump(
+                    {
+                        "selected_features": res["selected_features"],
+                        "selected_hyperparams": res["selected_hyperparams"],
+                        "pruning_history": res["pruning_history"],
+                        "candidate_metrics": res["candidate_metrics"],
+                        "comparison": res["comparison"],
+                    },
+                    f,
+                    indent=2,
+                )
+            if res.get("final_model_bundle"):
+                with open(model_path, "wb") as f:
+                    pickle.dump(res["final_model_bundle"], f)
+            processing_contract_path = out_dir / f"{stem}_processing_contract.json"
+            with open(processing_contract_path, "w", encoding="utf-8") as f:
+                json.dump(
+                    {
+                        "alpha_to_c_mapping": (
+                            "C = 1 / alpha" if _mode == "clf" else "not_applicable"
+                        ),
+                        "mode": _mode,
+                        "winsorization": "1-99 percentile per fold on train split only",
+                        "standardization": "z-score per fold on train split only",
+                        "uncertainty_direction_rule": "higher = more uncertain; vote_margin/vote_top_gap/leaf_support flipped",
+                        "required_outputs": (
+                            ["s_final_oof", "p_final_oof"]
+                            if _mode == "clf"
+                            else ["s_final_oof", "yhat_final_oof"]
+                        ),
+                        "live_inference_preprocess_keys": [
+                            "features",
+                            "lower",
+                            "upper",
+                            "mean",
+                            "std",
+                            "alpha",
+                            "l1_ratio",
+                            "C",
+                        ],
+                    },
+                    f,
+                    indent=2,
+                )
+            summary["processed"].append(
+                {
+                    "file": p.name,
+                    "metrics": str(metrics_path),
+                    "model": str(model_path),
+                    "processing_contract": str(processing_contract_path),
+                }
+            )
+            tprint(f"EN uncertainty combiner: processed {p.name}")
+        except Exception as exc:
+            summary["skipped"].append({"file": p.name, "reason": str(exc)})
+            tprint(f"EN uncertainty combiner: skipped {p.name} ({exc})")
+
+    with open(out_dir / "summary.json", "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="ElasticNet-based uncertainty OOF combiner"
+    )
+    parser.add_argument("--data-root", type=str, default="data")
+    parser.add_argument("--run-id", type=str, required=True)
+    args = parser.parse_args()
+    summary = run_on_artifacts(args.data_root, args.run_id)
+    tprint(
+        f"EN uncertainty combiner done: processed={len(summary['processed'])} skipped={len(summary['skipped'])}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/extreme_price_movements/meta_training/trade_filtering.py
+++ b/extreme_price_movements/meta_training/trade_filtering.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+import numpy as np
+import pandas as pd
+
+try:
+    from extreme_price_movements.src_utils_tprint import tprint
+except Exception:
+    tprint = print
+
+
+@dataclass(frozen=True)
+class TopRankMaskResult:
+    mask: np.ndarray
+    chosen_topx: int
+    coverage: float
+    score: float
+
+
+def get_or_select_top_rank_mask(
+    *,
+    strategy_id: str,
+    cache: dict[str, TopRankMaskResult] | None = None,
+    **kwargs,
+) -> TopRankMaskResult:
+    """Reuse a previously computed top-rank mask for the same strategy_id."""
+    sid = str(strategy_id or "").strip()
+    if cache is not None and sid and sid in cache:
+        cached = cache[sid]
+        tprint(
+            f"[trade_filtering] reusing cached mask for strategy_id={sid[:80]} "
+            f"topx={cached.chosen_topx} kept={int(cached.mask.sum())}/{len(cached.mask)}"
+        )
+        return cached
+
+    result = select_top_rank_mask(**kwargs)
+    if cache is not None and sid:
+        cache[sid] = result
+        tprint(
+            f"[trade_filtering] cached mask for strategy_id={sid[:80]} "
+            f"topx={result.chosen_topx} kept={int(result.mask.sum())}/{len(result.mask)}"
+        )
+    return result
+
+
+def rolling_asset_percentile(
+    scores: np.ndarray,
+    symbols: Iterable[Any],
+    timestamps: Iterable[Any] | None = None,
+    window: int = 240,
+) -> np.ndarray:
+    """Return causal rolling percentile rank in [0,1] per asset.
+
+    The current score is ranked against the previous `window` observations
+    for the same asset (excluding the current row to avoid look-ahead).
+    """
+    vals = np.asarray(scores, dtype=np.float32)
+    n = len(vals)
+    tprint(
+        f"[trade_filtering] rolling_asset_percentile start: n={n} window={int(window)}"
+    )
+    out = np.full(n, np.nan, dtype=np.float32)
+    if n == 0:
+        return out
+    sym = np.asarray(list(symbols))
+    ts = (
+        pd.to_datetime(list(timestamps), errors="coerce")
+        if timestamps is not None
+        else None
+    )
+
+    df = pd.DataFrame({"score": vals, "symbol": sym})
+    if ts is not None:
+        df["ts"] = ts
+        df = df.sort_values(["symbol", "ts"]).copy()
+    else:
+        df = df.copy()
+    df["orig_idx"] = np.arange(len(df), dtype=np.int64)
+
+    ranks = np.full(len(df), np.nan, dtype=np.float32)
+    for _, g in df.groupby("symbol", sort=False):
+        gv = g["score"].to_numpy(dtype=np.float32)
+        idx = g.index.to_numpy(dtype=np.int64)
+        for i in range(len(gv)):
+            lo = max(0, i - int(window))
+            hist = gv[lo:i]
+            if hist.size == 0 or not np.isfinite(gv[i]):
+                ranks[idx[i]] = np.nan
+                continue
+            finite = hist[np.isfinite(hist)]
+            if finite.size == 0:
+                ranks[idx[i]] = np.nan
+                continue
+            ranks[idx[i]] = float(np.mean(finite <= gv[i]))
+
+    if ts is not None:
+        back = pd.Series(ranks, index=df["orig_idx"].to_numpy(dtype=np.int64))
+        out = back.reindex(np.arange(n)).to_numpy(dtype=np.float32)
+    else:
+        out = ranks.astype(np.float32)
+    tprint(
+        f"[trade_filtering] rolling_asset_percentile done: finite={int(np.isfinite(out).sum())}/{n}"
+    )
+    return np.clip(out, 0.0, 1.0)
+
+
+def select_top_rank_mask(
+    *,
+    base_prob: np.ndarray,
+    strategy_mask: np.ndarray,
+    symbols: Iterable[Any],
+    timestamps: Iterable[Any] | None,
+    outcomes: np.ndarray,
+    mfe: np.ndarray | None,
+    mae: np.ndarray | None,
+    t_mfe: np.ndarray | None,
+    t_mae: np.ndarray | None,
+    tp: np.ndarray | None,
+    topx_values: tuple[int, ...] = (20, 25, 30, 35, 40),
+    rank_window: int = 240,
+) -> TopRankMaskResult:
+    """Choose top-x% rolling-rank mask maximizing lift*coverage*excess magnitude."""
+    p = np.asarray(base_prob, dtype=np.float32)
+    sm = np.asarray(strategy_mask, dtype=bool)
+    y = np.asarray(outcomes, dtype=np.float32)
+    n = len(p)
+    if len(sm) != n:
+        sm = np.ones(n, dtype=bool)
+    if n == 0 or int(sm.sum()) == 0:
+        tprint("[trade_filtering] select_top_rank_mask early-exit: empty input")
+        return TopRankMaskResult(
+            mask=np.zeros(n, dtype=bool),
+            chosen_topx=int(topx_values[0]),
+            coverage=0.0,
+            score=0.0,
+        )
+
+    pct = rolling_asset_percentile(
+        scores=p,
+        symbols=symbols,
+        timestamps=timestamps,
+        window=max(int(rank_window), 5),
+    )
+    valid = sm & np.isfinite(pct)
+    baseline_hit = float(np.mean(y[sm] >= 0.5)) if int(sm.sum()) else 0.0
+
+    mfe_v = np.asarray(mfe, dtype=np.float32) if mfe is not None else None
+    mae_v = np.asarray(mae, dtype=np.float32) if mae is not None else None
+    tmfe_v = np.asarray(t_mfe, dtype=np.float32) if t_mfe is not None else None
+    tmae_v = np.asarray(t_mae, dtype=np.float32) if t_mae is not None else None
+    tp_v = np.asarray(tp, dtype=np.float32) if tp is not None else None
+
+    best = (-1.0, int(topx_values[0]), np.zeros(n, dtype=bool), 0.0)
+    for x in topx_values:
+        thr = 1.0 - float(x) / 100.0
+        m = valid & (pct >= thr)
+        cov = float(np.mean(m))
+        if cov <= 0.0:
+            continue
+        y_frac = float(np.clip(0.10 / max(cov, 1e-6), 0.01, 1.0))
+        kept_idx = np.flatnonzero(m)
+        if kept_idx.size == 0:
+            continue
+        scores_kept = p[kept_idx]
+        n_top = max(1, int(np.ceil(y_frac * kept_idx.size)))
+        top_idx = kept_idx[np.argsort(scores_kept)[-n_top:]]
+        hit_top = float(np.mean(y[top_idx] >= 0.5)) if top_idx.size else 0.0
+        lift = hit_top / max(baseline_hit, 1e-6)
+
+        excess = 0.0
+        if (
+            mfe_v is not None
+            and mae_v is not None
+            and tmfe_v is not None
+            and tmae_v is not None
+            and tp_v is not None
+        ):
+            top_mfe = mfe_v[top_idx]
+            top_mae = mae_v[top_idx]
+            top_tmfe = tmfe_v[top_idx]
+            top_tmae = tmae_v[top_idx]
+            top_tp = np.clip(tp_v[top_idx], 1e-6, None)
+            tp_before_sl = (top_mfe >= top_tp) & (
+                (~np.isfinite(top_tmae)) | (top_tmfe <= top_tmae)
+            )
+            if tp_before_sl.any():
+                excess = float(
+                    np.mean(
+                        np.maximum(top_mfe[tp_before_sl] - top_tp[tp_before_sl], 0.0)
+                    )
+                )
+
+        score = float(lift * cov * max(excess, 1e-8))
+        if score > best[0]:
+            best = (score, int(x), m, cov)
+        tprint(
+            "[trade_filtering] candidate "
+            f"topx={int(x)} cov={cov:.4f} y_frac={y_frac:.4f} lift={lift:.4f} "
+            f"excess={excess:.6f} score={score:.6e}"
+        )
+
+    out = TopRankMaskResult(
+        mask=best[2], chosen_topx=best[1], coverage=float(best[3]), score=float(best[0])
+    )
+    tprint(
+        f"[trade_filtering] selected topx={out.chosen_topx} "
+        f"coverage={out.coverage:.4f} score={out.score:.6e} kept={int(out.mask.sum())}/{n}"
+    )
+    return out

--- a/extreme_price_movements/pipeline_steps.py
+++ b/extreme_price_movements/pipeline_steps.py
@@ -17,9 +17,6 @@ from extreme_price_movements.config import (
     HELPER_BASE_FEATURES,
     POSITION_SIZER_V2_FEATURE_CONFIG,
 )
-
-
-
 from extreme_price_movements.data_store import (
     _atomic_write_parquet,
     _ensure_feature_frame_index,
@@ -66,6 +63,7 @@ from extreme_price_movements.reports.bucket_report import (
     report_optimise,
     report_ridge_sizer,
 )
+
 try:
     from extreme_price_movements.reports.report_generator import (
         generate_backtest_report,
@@ -73,6 +71,7 @@ try:
         generate_training_report,
     )
 except ModuleNotFoundError:
+
     def generate_backtest_report(*args, **kwargs):
         raise ModuleNotFoundError(
             "extreme_price_movements.reports.report_generator is not available"
@@ -87,6 +86,11 @@ except ModuleNotFoundError:
         raise ModuleNotFoundError(
             "extreme_price_movements.reports.report_generator is not available"
         )
+
+
+from extreme_price_movements.feature_selection_extreme_events import (
+    mdi_feature_selection_v3,
+)
 from extreme_price_movements.ridge_position_sizer import (
     RidgePositionSizer,
     run_ridge_position_sizer_step,
@@ -100,10 +104,9 @@ from extreme_price_movements.telemetry.tprint_hooks import (
     emit_bucket_summary,
     emit_run_header,
 )
-from extreme_price_movements.feature_selection_extreme_events import mdi_feature_selection_v3
 from extreme_price_movements.training import (  # generate_spike_anatomy_history,
-    _build_base_regression_target,
     _build_base_regression_sample_weight,
+    _build_base_regression_target,
     _cap_selected_features,
     _subsample_indices_time_balanced,
     generate_label_datasets,
@@ -111,9 +114,9 @@ from extreme_price_movements.training import (  # generate_spike_anatomy_history
     train_models_from_artifacts,
 )
 from extreme_price_movements.training_utils import (
+    build_wide_tight_pair_features,
     get_base_feature_keys,
     get_meta_feature_keys,
-    build_wide_tight_pair_features,
 )
 from extreme_price_movements.universe import (
     apply_hardcoded_universe_exclusions,
@@ -485,7 +488,10 @@ def _labeling_feature_keys(cfg) -> set[str]:
         from extreme_price_movements.strategy_registry import get_strategies
 
         selected_strategies = cfg.get("strategies", [])
-        if not isinstance(selected_strategies, (list, tuple)) or not selected_strategies:
+        if (
+            not isinstance(selected_strategies, (list, tuple))
+            or not selected_strategies
+        ):
             selected_strategies = get_strategies(cfg)
         tprint(
             f"Label feature key scope: using {len(selected_strategies)} selected strategies"
@@ -523,7 +529,11 @@ def _align_features_to_panel(
 
         # Fast path: skip reindex if columns and index match exactly
         if list(df.columns) == list(symbols) and df.index.equals(close.index):
-            out[k] = df.astype(np.float32, copy=False) if df.dtypes.iloc[0] != np.float32 else df
+            out[k] = (
+                df.astype(np.float32, copy=False)
+                if df.dtypes.iloc[0] != np.float32
+                else df
+            )
         else:
             out[k] = df.reindex(index=close.index, columns=symbols).astype(
                 np.float32, copy=False
@@ -1496,7 +1506,9 @@ def run_label_generation_step_v2(ts_sig, margin_symbols, cfg, store, ex, horizon
     lookback_days = max(90, int(cfg["fetch_years"] * 365))
 
     from concurrent.futures import ThreadPoolExecutor, as_completed
+
     with Timer("Data Load"):
+
         def load_sym(s):
             df = store.load(s)
             if not df.empty:
@@ -1568,7 +1580,10 @@ def run_label_generation_step_v2(ts_sig, margin_symbols, cfg, store, ex, horizon
 
     # Keep feature-key selection consistent with the shared cache/feature generation logic.
     label_feature_keys = _labeling_feature_keys(cfg)
-    feats = load_features_for_stage_or_all(cfg, ts_sig, cfg["data_root"],
+    feats = load_features_for_stage_or_all(
+        cfg,
+        ts_sig,
+        cfg["data_root"],
         feature_keys=sorted(label_feature_keys),
         symbols=train_syms,
     )
@@ -1733,7 +1748,9 @@ def run_label_generation_step_v2(ts_sig, margin_symbols, cfg, store, ex, horizon
         ):
             with open(_manifest_path, "r", encoding="utf-8") as _mf:
                 _manifest_payload = json.load(_mf)
-            tprint(f"Preserving existing incremental labels manifest at {_manifest_path}")
+            tprint(
+                f"Preserving existing incremental labels manifest at {_manifest_path}"
+            )
         else:
             with open(_manifest_path, "w", encoding="utf-8") as _mf:
                 json.dump(_manifest_payload, _mf, indent=2, sort_keys=True)
@@ -1941,9 +1958,11 @@ def _consolidate_layer_oof_from_disk(
                 ("oof_sigma_robust", "robust_sigma"),
             ):
                 if sigma_col in df.columns:
-                    mini[_sigma_column_name(model_key, suffix)] = pd.to_numeric(
-                        df[sigma_col], errors="coerce"
-                    ).astype(np.float32).values[: len(mini)]
+                    mini[_sigma_column_name(model_key, suffix)] = (
+                        pd.to_numeric(df[sigma_col], errors="coerce")
+                        .astype(np.float32)
+                        .values[: len(mini)]
+                    )
             merged = (
                 mini
                 if merged.empty
@@ -1976,10 +1995,18 @@ def _consolidate_layer_oof_from_disk(
                 merged[wide_col].values,
                 merged[tight_col].values,
                 base_name=root,
-                sigma_wide=merged[sigma_wide_col].values if sigma_wide_col in merged.columns else None,
-                sigma_tight=merged[sigma_tight_col].values if sigma_tight_col in merged.columns else None,
-                robust_sigma_wide=merged[robust_sigma_wide_col].values if robust_sigma_wide_col in merged.columns else None,
-                robust_sigma_tight=merged[robust_sigma_tight_col].values if robust_sigma_tight_col in merged.columns else None,
+                sigma_wide=merged[sigma_wide_col].values
+                if sigma_wide_col in merged.columns
+                else None,
+                sigma_tight=merged[sigma_tight_col].values
+                if sigma_tight_col in merged.columns
+                else None,
+                robust_sigma_wide=merged[robust_sigma_wide_col].values
+                if robust_sigma_wide_col in merged.columns
+                else None,
+                robust_sigma_tight=merged[robust_sigma_tight_col].values
+                if robust_sigma_tight_col in merged.columns
+                else None,
             )
             pair_block = pd.DataFrame(pair_features, index=merged.index)
             merged = pd.concat([merged, pair_block], axis=1, copy=False)
@@ -2090,7 +2117,9 @@ def run_training_step(
                     tprint(f"  Loaded {vname}: {len(datasets[vname])} rows")
 
     if not include_variant_datasets:
-        tprint("Model-training dataset loader: primary-only mode, variant label artifacts are excluded.")
+        tprint(
+            "Model-training dataset loader: primary-only mode, variant label artifacts are excluded."
+        )
 
     tprint("Spike anatomy and specialist label datasets are disabled.")
 
@@ -2163,9 +2192,7 @@ def run_training_step(
         tprint(
             f"Base-only mode: Loading {len(req_keys)} req features (excluded {len(meta_keys - base_keys)} meta-only keys)"
         )
-        req_keys = _base_training_feature_requirements_from_hpo(
-            cfg, datasets, req_keys
-        )
+        req_keys = _base_training_feature_requirements_from_hpo(cfg, datasets, req_keys)
 
     datasets = inject_features_into_datasets(datasets, ts_sig, cfg, req_keys)
 
@@ -2196,6 +2223,21 @@ def run_training_step(
         alpha_metrics = (
             trained_bundle.get("alpha_oof_metrics", {}) if trained_bundle else {}
         )
+
+    if not meta_only:
+        try:
+            from extreme_price_movements.en_based_uncertainty_features_selection import (
+                run_on_artifacts as _run_en_uncertainty_combiner,
+            )
+
+            _en_summary = _run_en_uncertainty_combiner(cfg["data_root"], run_id)
+            tprint(
+                "EN uncertainty combiner: "
+                f"processed={len(_en_summary.get('processed', []))} "
+                f"skipped={len(_en_summary.get('skipped', []))}"
+            )
+        except Exception as _e_en:
+            tprint(f"EN uncertainty combiner skipped: {_e_en}")
 
     # Specialist Models are now trained inside train_models_from_artifacts
     # using artifacts loaded above.
@@ -2867,11 +2909,12 @@ def run_base_hpo_step(ts_sig, cfg):
     and horizon). Each scope now follows:
     MDI feature selection -> HPO -> final training.
     """
+    from sklearn.ensemble import ExtraTreesRegressor
+
     from extreme_price_movements.post_race_hpo import (
         run_base_extratrees_hpo,
         run_base_extratrees_reg_hpo,
     )
-    from sklearn.ensemble import ExtraTreesRegressor
 
     run_id = ts_sig.strftime("%Y%m%d_%H%M%S")
     data_root = cfg.get("data_root", "data")
@@ -2915,7 +2958,11 @@ def run_base_hpo_step(ts_sig, cfg):
             tprint(f"BASE HPO: no data rows loaded for strategy {s_id}.")
             continue
 
-        base_req_keys = set(str(v) for v in (strat.get("feature_keys") or []) if isinstance(v, str) and v)
+        base_req_keys = set(
+            str(v)
+            for v in (strat.get("feature_keys") or [])
+            if isinstance(v, str) and v
+        )
         base_req_keys.update(
             {
                 "p_exh_lag1",
@@ -2992,7 +3039,9 @@ def run_base_hpo_step(ts_sig, cfg):
                 X_all = X_all[valid_y_mask]
                 y_all = y_all[valid_y_mask]
                 sym_col = sym_col[valid_y_mask]
-                df_hpo = df_hpo.iloc[np.flatnonzero(valid_y_mask)].reset_index(drop=True)
+                df_hpo = df_hpo.iloc[np.flatnonzero(valid_y_mask)].reset_index(
+                    drop=True
+                )
 
             if X_all.size == 0 or y_all.size == 0:
                 tprint(f"BASE HPO[{name}]: empty matrix after target filtering.")
@@ -3001,7 +3050,9 @@ def run_base_hpo_step(ts_sig, cfg):
             missing_frac = float(np.mean(~np.isfinite(X_all)))
             if missing_frac > 0.0:
                 col_medians = np.nanmedian(X_all, axis=0)
-                col_medians = np.where(np.isfinite(col_medians), col_medians, 0.0).astype(
+                col_medians = np.where(
+                    np.isfinite(col_medians), col_medians, 0.0
+                ).astype(
                     np.float32,
                     copy=False,
                 )
@@ -3028,7 +3079,9 @@ def run_base_hpo_step(ts_sig, cfg):
             _mdi_min = min(
                 int(
                     cfg.get(
-                        "base_variant_mdi_min_features" if is_variant_scope else "base_mdi_min_features",
+                        "base_variant_mdi_min_features"
+                        if is_variant_scope
+                        else "base_mdi_min_features",
                         30,
                     )
                 ),
@@ -3052,13 +3105,19 @@ def run_base_hpo_step(ts_sig, cfg):
                 base_model=mdi_base,
                 sample_weight=None,
                 selector_y=y_all[_sel_idx],
-                selector_target=str(cfg.get("base_mdi_selector_target", "classification")),
+                selector_target=str(
+                    cfg.get("base_mdi_selector_target", "classification")
+                ),
                 selector_loss=str(cfg.get("base_mdi_selector_loss", "binary_logloss")),
                 selector_head_name=f"base_{name}",
                 selector_report_dir=_selector_report_dir,
                 selector_prev_selected=None,
-                selector_family_map=dict(cfg.get("selector_feature_family_map", {}) or {}),
-                selector_focus_top_frac=float(_base_sel_cfg.get("selector_focus_top_frac", 1.0)),
+                selector_family_map=dict(
+                    cfg.get("selector_feature_family_map", {}) or {}
+                ),
+                selector_focus_top_frac=float(
+                    _base_sel_cfg.get("selector_focus_top_frac", 1.0)
+                ),
                 selector_top_metric=_base_sel_cfg.get("selector_top_metric", "ic"),
                 selector_frequency_hit_mode=str(
                     _base_sel_cfg.get("selector_frequency_hit_mode", "relative")
@@ -3084,10 +3143,18 @@ def run_base_hpo_step(ts_sig, cfg):
                 selector_family_penalty=bool(
                     _base_sel_cfg.get("selector_family_penalty", True)
                 ),
-                selector_emit_report=bool(_base_sel_cfg.get("selector_emit_report", True)),
-                analysis_n_estimators=int(_base_sel_cfg.get("analysis_n_estimators", 192)),
-                analysis_max_samples=int(_base_sel_cfg.get("analysis_max_samples", 3000)),
-                min_samples_leaf_pct=float(_base_sel_cfg.get("min_samples_leaf_pct", 0.015)),
+                selector_emit_report=bool(
+                    _base_sel_cfg.get("selector_emit_report", True)
+                ),
+                analysis_n_estimators=int(
+                    _base_sel_cfg.get("analysis_n_estimators", 192)
+                ),
+                analysis_max_samples=int(
+                    _base_sel_cfg.get("analysis_max_samples", 3000)
+                ),
+                min_samples_leaf_pct=float(
+                    _base_sel_cfg.get("min_samples_leaf_pct", 0.015)
+                ),
                 selector_max_missing_frac=float(
                     _base_sel_cfg.get("selector_max_missing_frac", 0.15)
                 ),
@@ -3097,7 +3164,9 @@ def run_base_hpo_step(ts_sig, cfg):
                 selector_hysteresis_margin=float(
                     _base_sel_cfg.get("selector_hysteresis_margin", 0.05)
                 ),
-                selector_min_overlap=float(_base_sel_cfg.get("selector_min_overlap", 0.70)),
+                selector_min_overlap=float(
+                    _base_sel_cfg.get("selector_min_overlap", 0.70)
+                ),
                 composite_weights={
                     "top30": float(_base_sel_cfg.get("top30", 0.0)),
                     "global": float(_base_sel_cfg.get("global", 0.55)),
@@ -3134,8 +3203,12 @@ def run_base_hpo_step(ts_sig, cfg):
                 n_splits=int(cfg.get("base_hpo_n_splits", 3)),
                 max_rows=int(cfg.get("base_hpo_max_rows", 6500)),
                 optuna_patience_trials=int(cfg.get("base_hpo_patience_trials", 30)),
-                optuna_min_trials_before_stop=int(cfg.get("base_hpo_min_trials_before_stop", 50)),
-                optuna_meaningful_improvement_pct=float(cfg.get("base_hpo_meaningful_improvement_pct", 0.005)),
+                optuna_min_trials_before_stop=int(
+                    cfg.get("base_hpo_min_trials_before_stop", 50)
+                ),
+                optuna_meaningful_improvement_pct=float(
+                    cfg.get("base_hpo_meaningful_improvement_pct", 0.005)
+                ),
                 out_dir=hpo_out_dir,
                 study_name=f"base_extratrees_hpo_{name}",
                 scope_key=name,
@@ -3161,7 +3234,9 @@ def run_base_hpo_step(ts_sig, cfg):
                         reg_target_bundle["residualized_return"], dtype=np.float32
                     ),
                 )
-                reg_w_all = np.asarray(reg_weight_bundle["sample_weight"], dtype=np.float32)
+                reg_w_all = np.asarray(
+                    reg_weight_bundle["sample_weight"], dtype=np.float32
+                )
                 _reg_sel_cfg = dict(cfg.get("base_reg_selector_cfg", {}) or {})
                 if not _reg_sel_cfg:
                     _reg_sel_cfg = dict(_base_sel_cfg)
@@ -3213,7 +3288,9 @@ def run_base_hpo_step(ts_sig, cfg):
                         _reg_sel_cfg.get("selector_interaction_topk_pairs", 100)
                     ),
                     selector_interaction_max_pairs_per_feature=int(
-                        _reg_sel_cfg.get("selector_interaction_max_pairs_per_feature", 8)
+                        _reg_sel_cfg.get(
+                            "selector_interaction_max_pairs_per_feature", 8
+                        )
                     ),
                     selector_interaction_corr_penalty=bool(
                         _reg_sel_cfg.get("selector_interaction_corr_penalty", True)
@@ -3356,9 +3433,7 @@ def _extract_required_features(bundle, cfg):
         ):
             _vals = getattr(_model, _attr, None)
             if isinstance(_vals, (list, tuple, set)):
-                _added = {
-                    str(v) for v in _vals if isinstance(v, str) and v
-                }
+                _added = {str(v) for v in _vals if isinstance(v, str) and v}
                 model_feature_count += len(_added)
                 _req.update(_added)
 
@@ -3766,7 +3841,10 @@ def run_backtest_step(ts_sig, margin_symbols, cfg, store, state_file):
             feat_start_ts = min(df.index.min() for df in dfs.values() if not df.empty)
         except ValueError:
             feat_start_ts = None
-    feats = load_features_for_stage_or_all(cfg, ts_sig, cfg["data_root"],
+    feats = load_features_for_stage_or_all(
+        cfg,
+        ts_sig,
+        cfg["data_root"],
         feature_keys=req_feats,
         symbols=train_syms,
         start_ts=feat_start_ts,
@@ -5938,9 +6016,7 @@ def run_feature_generation_step(
         if close_panel_light is not None and not close_panel_light.empty
         else panel_close_ref
     )
-    snapshot_expected_keys = {
-        k for k in expected_keys if not str(k).startswith("oof_")
-    }
+    snapshot_expected_keys = {k for k in expected_keys if not str(k).startswith("oof_")}
     skip_snapshot_validation = bool(cfg.get("skip_feature_snapshot_validation", False))
     skip_postsave_checks = bool(cfg.get("skip_feature_postsave_checks", False))
     if skip_snapshot_validation or skip_postsave_checks:
@@ -5967,7 +6043,10 @@ def run_feature_generation_step(
         _generate_feature_health_reports(
             ts_sig, cfg["data_root"], allowed_symbols=train_syms
         )
-        health_feats = load_features_for_stage_or_all(cfg, ts_sig, cfg["data_root"],
+        health_feats = load_features_for_stage_or_all(
+            cfg,
+            ts_sig,
+            cfg["data_root"],
             feature_keys=FEATURE_HEALTH_CRITICAL_KEYS,
             symbols=train_syms,
         )
@@ -5988,16 +6067,18 @@ def run_feature_generation_step(
 
 
 def inject_features_into_datasets(datasets, ts_sig, cfg, req_keys):
+    import time
+
     import numpy as np
     import pandas as pd
     import pyarrow.parquet as pq
-    import time
 
     from extreme_price_movements.data_store import (
         _build_parquet_ts_filters,
         get_feature_path,
     )
     from extreme_price_movements.utils import tprint
+
     if not datasets or not req_keys:
         return datasets
 
@@ -6103,7 +6184,9 @@ def inject_features_into_datasets(datasets, ts_sig, cfg, req_keys):
         }
         if not missing:
             continue
-        ts_index = pd.DatetimeIndex(pd.to_datetime(df[t_col], utc=True, errors="coerce"))
+        ts_index = pd.DatetimeIndex(
+            pd.to_datetime(df[t_col], utc=True, errors="coerce")
+        )
         dataset_ts_index[name] = ts_index
         symbol_positions = (
             pd.Series(np.arange(len(df), dtype=np.int32))
@@ -6195,14 +6278,22 @@ def inject_features_into_datasets(datasets, ts_sig, cfg, req_keys):
             read_kwargs = {}
             if "ts" in schema_cols:
                 read_cols = ["ts", *read_cols]
-                if sym_bounds and sym_bounds[0] is not None and sym_bounds[1] is not None:
+                if (
+                    sym_bounds
+                    and sym_bounds[0] is not None
+                    and sym_bounds[1] is not None
+                ):
                     read_kwargs["filters"] = _build_parquet_ts_filters(
                         start_ts=sym_bounds[0],
                         end_ts=sym_bounds[1] + pd.Timedelta(seconds=1),
                     )
             elif "timestamp" in schema_cols:
                 read_cols = ["timestamp", *read_cols]
-                if sym_bounds and sym_bounds[0] is not None and sym_bounds[1] is not None:
+                if (
+                    sym_bounds
+                    and sym_bounds[0] is not None
+                    and sym_bounds[1] is not None
+                ):
                     start_ts = pd.Timestamp(sym_bounds[0])
                     end_ts = pd.Timestamp(sym_bounds[1] + pd.Timedelta(seconds=1))
                     if start_ts.tzinfo is None:
@@ -6381,7 +6472,9 @@ def _base_training_feature_requirements_from_hpo(cfg, datasets, default_req_keys
     default_req_keys = sorted(set(default_req_keys))
 
     for name in datasets.keys():
-        payload_clf = load_best_base_extratrees_payload(str(hpo_out_dir), scope_key=name)
+        payload_clf = load_best_base_extratrees_payload(
+            str(hpo_out_dir), scope_key=name
+        )
         payload_reg = load_best_base_extratrees_payload(
             str(hpo_out_dir), scope_key=f"{name}__reg_head"
         )
@@ -6402,6 +6495,7 @@ def _base_training_feature_requirements_from_hpo(cfg, datasets, default_req_keys
         return out
     return default_req_keys
 
+
 def _filter_artifact_by_stage_view(df, cfg):
     view = cfg.get("_active_stage_view")
     if not view or df is None or df.empty:
@@ -6411,13 +6505,27 @@ def _filter_artifact_by_stage_view(df, cfg):
     stage_name = view.get("stage_name", "unknown_stage")
 
     if "symbols" in view and view["symbols"] is not None:
-        sym_col = "__symbol__" if "__symbol__" in df.columns else "symbol" if "symbol" in df.columns else None
+        sym_col = (
+            "__symbol__"
+            if "__symbol__" in df.columns
+            else "symbol"
+            if "symbol" in df.columns
+            else None
+        )
         if sym_col:
             df = df[df[sym_col].isin(view["symbols"])]
 
     periods = view.get("allowed_periods") or None
     if periods:
-        ts_col = "__ts__" if "__ts__" in df.columns else "timestamp" if "timestamp" in df.columns else "t0" if "t0" in df.columns else None
+        ts_col = (
+            "__ts__"
+            if "__ts__" in df.columns
+            else "timestamp"
+            if "timestamp" in df.columns
+            else "t0"
+            if "t0" in df.columns
+            else None
+        )
         if ts_col:
             df_ts = pd.to_datetime(df[ts_col], utc=True, errors="coerce")
             mask = np.zeros(len(df), dtype=bool)
@@ -6437,7 +6545,15 @@ def _filter_artifact_by_stage_view(df, cfg):
             df = df.loc[mask]
 
     if view.get("allowed_start_ts") or view.get("allowed_end_ts"):
-        ts_col = "__ts__" if "__ts__" in df.columns else "timestamp" if "timestamp" in df.columns else "t0" if "t0" in df.columns else None
+        ts_col = (
+            "__ts__"
+            if "__ts__" in df.columns
+            else "timestamp"
+            if "timestamp" in df.columns
+            else "t0"
+            if "t0" in df.columns
+            else None
+        )
         if ts_col:
             df_ts = pd.to_datetime(df[ts_col], utc=True)
             if view.get("allowed_start_ts"):
@@ -6448,15 +6564,31 @@ def _filter_artifact_by_stage_view(df, cfg):
 
     new_len = len(df)
     if orig_len != new_len:
-        tprint(f"[{stage_name}] Filtered artifact: {orig_len} -> {new_len} rows (-{orig_len - new_len}) based on active stage limits.")
+        tprint(
+            f"[{stage_name}] Filtered artifact: {orig_len} -> {new_len} rows (-{orig_len - new_len}) based on active stage limits."
+        )
 
     return df
     if "symbols" in view and view["symbols"] is not None:
-        sym_col = "__symbol__" if "__symbol__" in df.columns else "symbol" if "symbol" in df.columns else None
+        sym_col = (
+            "__symbol__"
+            if "__symbol__" in df.columns
+            else "symbol"
+            if "symbol" in df.columns
+            else None
+        )
         if sym_col:
             df = df[df[sym_col].isin(view["symbols"])]
     if view.get("allowed_start_ts") or view.get("allowed_end_ts"):
-        ts_col = "__ts__" if "__ts__" in df.columns else "timestamp" if "timestamp" in df.columns else "t0" if "t0" in df.columns else None
+        ts_col = (
+            "__ts__"
+            if "__ts__" in df.columns
+            else "timestamp"
+            if "timestamp" in df.columns
+            else "t0"
+            if "t0" in df.columns
+            else None
+        )
         if ts_col:
             df_ts = pd.to_datetime(df[ts_col], utc=True)
             if view.get("allowed_start_ts"):
@@ -6465,7 +6597,6 @@ def _filter_artifact_by_stage_view(df, cfg):
             if view.get("allowed_end_ts"):
                 df = df[df_ts <= pd.to_datetime(view["allowed_end_ts"])]
     return df
-
 
     tprint("Resolving unique symbols and timestamps for feature injection...")
     all_syms = set()

--- a/extreme_price_movements/simple_position_sizer.py
+++ b/extreme_price_movements/simple_position_sizer.py
@@ -34,6 +34,7 @@ try:
 except ImportError:
     LGBMRegressor = None  # type: ignore[assignment, misc]
 
+from extreme_price_movements.meta_training.trade_filtering import select_top_rank_mask
 from extreme_price_movements.metrics import _stable_equity_and_drawdown
 from extreme_price_movements.offline_optimisers.params_store import (
     load_inference_candidate_mask_params_per_bucket,
@@ -5391,6 +5392,89 @@ def run_simple_position_sizer_from_artifacts(
         trade_outcomes = trade_outcomes.loc[np.asarray(scorable_mask)].reset_index(
             drop=True
         )
+
+        _base_prob_col = next(
+            (
+                c
+                for c in [
+                    "oof_prob",
+                    "clf",
+                    "pred",
+                    "oof_pred",
+                    "base_h4",
+                    "base_h2",
+                ]
+                if c in active_df.columns
+            ),
+            None,
+        )
+        if _base_prob_col is not None and len(active_df) == len(trade_outcomes):
+            _asset_col = (
+                "symbol"
+                if "symbol" in active_df.columns
+                else "__symbol__"
+                if "__symbol__" in active_df.columns
+                else None
+            )
+            _ts_col = (
+                "timestamp"
+                if "timestamp" in active_df.columns
+                else "__ts__"
+                if "__ts__" in active_df.columns
+                else None
+            )
+            _side_ret = np.asarray(trade_outcomes["return"].values, dtype=np.float32)
+            _y_bin = (_side_ret > 0).astype(np.float32)
+            _mask_res = select_top_rank_mask(
+                base_prob=np.asarray(
+                    active_df[_base_prob_col].values, dtype=np.float32
+                ),
+                strategy_mask=np.ones(len(active_df), dtype=bool),
+                symbols=(
+                    np.asarray(active_df[_asset_col].astype(str).values)
+                    if _asset_col is not None
+                    else np.asarray(np.repeat("all", len(active_df)))
+                ),
+                timestamps=(
+                    pd.to_datetime(active_df[_ts_col], errors="coerce")
+                    if _ts_col is not None
+                    else None
+                ),
+                outcomes=_y_bin,
+                mfe=(
+                    np.asarray(trade_outcomes["mfe_ret"].values, dtype=np.float32)
+                    if "mfe_ret" in trade_outcomes.columns
+                    else None
+                ),
+                mae=(
+                    np.asarray(trade_outcomes["mae_ret"].values, dtype=np.float32)
+                    if "mae_ret" in trade_outcomes.columns
+                    else None
+                ),
+                t_mfe=(
+                    np.asarray(trade_outcomes["t_mfe"].values, dtype=np.float32)
+                    if "t_mfe" in trade_outcomes.columns
+                    else None
+                ),
+                t_mae=(
+                    np.asarray(trade_outcomes["t_mae"].values, dtype=np.float32)
+                    if "t_mae" in trade_outcomes.columns
+                    else None
+                ),
+                tp=(
+                    np.asarray(active_df["__barrier_pct__"].values, dtype=np.float32)
+                    if "__barrier_pct__" in active_df.columns
+                    else np.full(len(active_df), 0.02, dtype=np.float32)
+                ),
+            )
+            _rank_mask = np.asarray(_mask_res.mask, dtype=bool)
+            if int(np.sum(_rank_mask)) > 50:
+                active_df = active_df.loc[_rank_mask].reset_index(drop=True)
+                trade_outcomes = trade_outcomes.loc[_rank_mask].reset_index(drop=True)
+                logger.info(
+                    f"Applied top-rank trade mask in sizer: topx={_mask_res.chosen_topx}% "
+                    f"coverage={_mask_res.coverage:.3f} kept={int(np.sum(_rank_mask))}/{len(_rank_mask)}"
+                )
 
         # Identify columns to use as heads.
         # STRICT RULE: never use realized-outcome columns as predictive heads — they are

--- a/extreme_price_movements/training.py
+++ b/extreme_price_movements/training.py
@@ -34,6 +34,10 @@ from .gamma_specialist import build_gamma_dataset, train_gamma_from_dataset
 from .gate_metrics import compute_stage_gate_metrics
 from .labeling import compute_trailing_atr_labels, compute_triple_barrier_labels
 from .meta_model import MetaClassifierModel, MetaModel
+from .meta_training.trade_filtering import (
+    get_or_select_top_rank_mask,
+    rolling_asset_percentile,
+)
 from .meta_training.utility_smooth import (
     smooth_utility_from_log_heads,
     smooth_utility_from_log_heads_standardized,
@@ -11744,6 +11748,7 @@ def train_meta_models_from_artifacts(
         _t_aligned_start = _time.monotonic()
         _bucket_key = f"{side}_{k}"
         _bucket_n = int(len(df))
+        _fit_mask_local = np.asarray(trade_mask, dtype=bool)
         _bucket_horizons = sorted({int(h) for h in (bucket_horizons or [])})
         _native_bucket_h = (
             int(_bucket_horizons[0]) if len(_bucket_horizons) == 1 else None
@@ -11963,6 +11968,7 @@ def train_meta_models_from_artifacts(
                 _target = np.log1p(
                     np.clip(np.asarray(_target_src, dtype=np.float32) / _bp, 0.0, None)
                 )
+                _target = np.where(np.asarray(trade_mask, dtype=bool), _target, np.nan)
                 _weights = _meta_map_weights(_target, df, trade_mask)
                 _head_name = f"{_bucket_key}_mae_h{int(_h)}"
                 _model = _configure_meta_reg(_head_name, "aux_mae_selector_cfg")
@@ -11971,10 +11977,14 @@ def train_meta_models_from_artifacts(
                     f"hpo_trials={_meta_hpo_trials}"
                 )
                 _model.fit(
-                    X_meta_base,
-                    _target,
-                    sample_weight=_weights,
-                    groups=meta_groups,
+                    X_meta_base.loc[_fit_mask_local].reset_index(drop=True),
+                    np.asarray(_target, dtype=float)[_fit_mask_local],
+                    sample_weight=np.asarray(_weights, dtype=float)[_fit_mask_local],
+                    groups=(
+                        np.asarray(meta_groups)[_fit_mask_local]
+                        if meta_groups is not None
+                        else None
+                    ),
                     y_per_horizon=None,
                 )
                 meta_models[_head_name] = _model
@@ -12002,6 +12012,7 @@ def train_meta_models_from_artifacts(
                 _target = np.log1p(
                     np.clip(np.asarray(_target_src, dtype=np.float32) / _bp, 0.0, None)
                 )
+                _target = np.where(np.asarray(trade_mask, dtype=bool), _target, np.nan)
                 _weights = _meta_map_weights(_target, df, trade_mask)
                 _head_name = f"{_bucket_key}_mfe_h{int(_h)}"
                 _model = _configure_meta_reg(_head_name, "aux_mfe_selector_cfg")
@@ -12010,10 +12021,14 @@ def train_meta_models_from_artifacts(
                     f"hpo_trials={_meta_hpo_trials}"
                 )
                 _model.fit(
-                    X_meta_base,
-                    _target,
-                    sample_weight=_weights,
-                    groups=meta_groups,
+                    X_meta_base.loc[_fit_mask_local].reset_index(drop=True),
+                    np.asarray(_target, dtype=float)[_fit_mask_local],
+                    sample_weight=np.asarray(_weights, dtype=float)[_fit_mask_local],
+                    groups=(
+                        np.asarray(meta_groups)[_fit_mask_local]
+                        if meta_groups is not None
+                        else None
+                    ),
                     y_per_horizon=None,
                 )
                 meta_models[_head_name] = _model
@@ -12145,22 +12160,32 @@ def train_meta_models_from_artifacts(
                     f"hpo_trials={_meta_hpo_trials} move_h={_mid_h}"
                 )
                 _clf.fit(
-                    X_meta_base,
-                    _y_mid,
-                    sample_weight=_weights_clf,
-                    groups=meta_groups,
+                    X_meta_base.loc[_fit_mask_local].reset_index(drop=True),
+                    np.asarray(_y_mid, dtype=float)[_fit_mask_local],
+                    sample_weight=np.asarray(_weights_clf, dtype=float)[
+                        _fit_mask_local
+                    ],
+                    groups=(
+                        np.asarray(meta_groups)[_fit_mask_local]
+                        if meta_groups is not None
+                        else None
+                    ),
                     y_per_horizon={
                         int(h): _align_bucket_vec(
                             ret_for_h(int(h)), fill_value=np.nan, dtype=np.float64
-                        )
+                        )[_fit_mask_local]
                         for h in _bucket_horizons
                     },
-                    vol_proxy=_bp_move,
-                    realized_u_policy=np.abs(_y_mid),
+                    vol_proxy=np.asarray(_bp_move, dtype=float)[_fit_mask_local],
+                    realized_u_policy=np.abs(np.asarray(_y_mid, dtype=float))[
+                        _fit_mask_local
+                    ],
                     selection_cfg=_sel_cfg,
-                    y_move_override=_y_move_soft,
-                    y_class_override=_y_move,
-                    trade_mask=np.asarray(trade_mask, dtype=bool),
+                    y_move_override=np.asarray(_y_move_soft, dtype=float)[
+                        _fit_mask_local
+                    ],
+                    y_class_override=np.asarray(_y_move, dtype=float)[_fit_mask_local],
+                    trade_mask=np.asarray(trade_mask, dtype=bool)[_fit_mask_local],
                     move_thresholds=_move_thresholds,
                     move_weights=_move_weights,
                     use_class_weight_multiplier=bool(
@@ -12220,22 +12245,34 @@ def train_meta_models_from_artifacts(
                         require_positive_base_rate=False,
                     )
                     _clf_fb.fit(
-                        X_meta_base,
-                        _y_mid,
-                        sample_weight=_weights_clf,
-                        groups=meta_groups,
+                        X_meta_base.loc[_fit_mask_local].reset_index(drop=True),
+                        np.asarray(_y_mid, dtype=float)[_fit_mask_local],
+                        sample_weight=np.asarray(_weights_clf, dtype=float)[
+                            _fit_mask_local
+                        ],
+                        groups=(
+                            np.asarray(meta_groups)[_fit_mask_local]
+                            if meta_groups is not None
+                            else None
+                        ),
                         y_per_horizon={
                             int(h): _align_bucket_vec(
                                 ret_for_h(int(h)), fill_value=np.nan, dtype=np.float64
-                            )
+                            )[_fit_mask_local]
                             for h in _bucket_horizons
                         },
-                        vol_proxy=_bp_move,
-                        realized_u_policy=np.abs(_y_mid),
+                        vol_proxy=np.asarray(_bp_move, dtype=float)[_fit_mask_local],
+                        realized_u_policy=np.abs(np.asarray(_y_mid, dtype=float))[
+                            _fit_mask_local
+                        ],
                         selection_cfg=_sel_cfg_fb,
-                        y_move_override=_y_move_soft,
-                        y_class_override=_y_move,
-                        trade_mask=np.asarray(trade_mask, dtype=bool),
+                        y_move_override=np.asarray(_y_move_soft, dtype=float)[
+                            _fit_mask_local
+                        ],
+                        y_class_override=np.asarray(_y_move, dtype=float)[
+                            _fit_mask_local
+                        ],
+                        trade_mask=np.asarray(trade_mask, dtype=bool)[_fit_mask_local],
                         move_thresholds=_move_thresholds,
                         move_weights=_move_weights,
                         use_class_weight_multiplier=False,
@@ -12272,6 +12309,7 @@ def train_meta_models_from_artifacts(
             _cal_target = _build_base_correctness_target_for_h(int(primary_h))
             _cal_residual = np.asarray(_cal_target["residual"], dtype=np.float32)
             _cal_valid = np.asarray(_cal_target["valid_mask"], dtype=bool)
+            _cal_valid &= np.asarray(trade_mask, dtype=bool)
             _cal_confidence = np.asarray(_cal_target["confidence"], dtype=np.float32)
             _cal_valid_r = _cal_residual[_cal_valid]
             _q33 = float(np.percentile(_cal_valid_r, 33.33))
@@ -13171,17 +13209,181 @@ def train_meta_models_from_artifacts(
         meta_interaction_cols: list[str] = []
         _base_prob_h = int(_strategy_primary_h)
         _base_prob_col = (
-            f"pred_{k}_H{int(_base_prob_h)}"
-            if f"pred_{k}_H{int(_base_prob_h)}" in X_meta_base.columns
+            "p_final_oof"
+            if "p_final_oof" in X_meta_base.columns
             else (
-                f"pred_H{int(_base_prob_h)}"
-                if f"pred_H{int(_base_prob_h)}" in X_meta_base.columns
-                else None
+                "s_final_oof"
+                if "s_final_oof" in X_meta_base.columns
+                else (
+                    f"pred_{k}_H{int(_base_prob_h)}"
+                    if f"pred_{k}_H{int(_base_prob_h)}" in X_meta_base.columns
+                    else (
+                        f"pred_H{int(_base_prob_h)}"
+                        if f"pred_H{int(_base_prob_h)}" in X_meta_base.columns
+                        else None
+                    )
+                )
             )
         )
         if _base_prob_col is not None:
             _base_prob_vals = np.asarray(
                 X_meta_base[_base_prob_col].values, dtype=np.float32
+            )
+            _asset_col = (
+                "__symbol__"
+                if "__symbol__" in df.columns
+                else "symbol"
+                if "symbol" in df.columns
+                else None
+            )
+            _asset_vals = (
+                np.asarray(df[_asset_col].astype(str).values)
+                if _asset_col is not None
+                else np.asarray(np.repeat("all", len(df)))
+            )
+            _ts_vals = (
+                pd.to_datetime(df["__ts__"], errors="coerce")
+                if "__ts__" in df.columns
+                else pd.to_datetime(df["timestamp"], errors="coerce")
+                if "timestamp" in df.columns
+                else None
+            )
+            _rank_window = int(cfg.get("meta_trade_rank_window", 240))
+            _base_rank_pct = rolling_asset_percentile(
+                _base_prob_vals, _asset_vals, _ts_vals, window=_rank_window
+            )
+            X_meta_base["base_model_score"] = _base_prob_vals.astype(
+                np.float32, copy=False
+            )
+            X_meta_base["base_model_score_pct"] = _base_rank_pct.astype(
+                np.float32, copy=False
+            )
+            _base_outcome = (
+                np.asarray(df["__y_bin__"].values, dtype=np.float32)
+                if "__y_bin__" in df.columns
+                else np.full(len(df), np.nan, dtype=np.float32)
+            )
+            X_meta_base["base_model_margin"] = np.abs(
+                _base_prob_vals - np.nan_to_num(_base_outcome, nan=0.5)
+            ).astype(np.float32, copy=False)
+            _meta_prob_err = np.full(len(df), np.nan, dtype=np.float32)
+            _recent_prob_err_20 = np.full(len(df), np.nan, dtype=np.float32)
+            _recent_hit_rate_20 = np.full(len(df), np.nan, dtype=np.float32)
+            _prob_pred = (_base_prob_vals >= 0.5).astype(np.int8)
+            _rank_top10 = _base_rank_pct >= 0.90
+            _work = pd.DataFrame(
+                {
+                    "asset": _asset_vals,
+                    "base_prob": _base_prob_vals,
+                    "outcome": _base_outcome,
+                    "rank_top10": _rank_top10,
+                    "pred_label": _prob_pred,
+                }
+            )
+            for _asset, _grp in _work.groupby("asset", sort=False):
+                _idx = _grp.index.to_numpy(dtype=np.int64)
+                _p = _grp["base_prob"].to_numpy(dtype=np.float32)
+                _o = _grp["outcome"].to_numpy(dtype=np.float32)
+                _pe = np.abs(np.roll(_p, 1) - np.roll(_o, 1)).astype(np.float32)
+                if _pe.size > 0:
+                    _pe[0] = np.nan
+                _meta_prob_err[_idx] = _pe
+                _recent_prob_err_20[_idx] = (
+                    pd.Series(_pe).rolling(20, min_periods=5).mean().to_numpy()
+                )
+                _hit = (
+                    _grp["pred_label"].to_numpy(dtype=np.int8) == (_o >= 0.5)
+                ).astype(np.float32)
+                _hit_top = _hit[_grp["rank_top10"].to_numpy(dtype=bool)]
+                _hit_roll = (
+                    pd.Series(_hit_top).rolling(20, min_periods=5).mean().to_numpy()
+                    if _hit_top.size > 0
+                    else np.array([], dtype=np.float32)
+                )
+                _hit_series = np.full(len(_grp), np.nan, dtype=np.float32)
+                if _hit_roll.size > 0:
+                    _top_idx_local = np.flatnonzero(
+                        _grp["rank_top10"].to_numpy(dtype=bool)
+                    )
+                    _hit_series[_top_idx_local] = _hit_roll.astype(np.float32)
+                    _hit_series = (
+                        pd.Series(_hit_series)
+                        .ffill()
+                        .fillna(method="bfill")
+                        .to_numpy(dtype=np.float32)
+                    )
+                _recent_hit_rate_20[_idx] = _hit_series
+            X_meta_base["prob_error"] = _meta_prob_err.astype(np.float32, copy=False)
+            X_meta_base["recent_prob_error_20"] = _recent_prob_err_20.astype(
+                np.float32, copy=False
+            )
+            X_meta_base["recent_hit_rate_20"] = _recent_hit_rate_20.astype(
+                np.float32, copy=False
+            )
+            X_meta_base["base_model_abs_error_roll20"] = (
+                pd.Series(
+                    np.abs(_base_prob_vals - np.nan_to_num(_base_outcome, nan=0.5))
+                )
+                .rolling(20, min_periods=5)
+                .mean()
+                .to_numpy(dtype=np.float32)
+            )
+
+            _native_exc = None
+            _mfe_col = f"__meta_raw__mfe_{int(_strategy_primary_h)}h"
+            _mae_col = f"__meta_raw__mae_{int(_strategy_primary_h)}h"
+            _t_mfe_col = f"__meta_raw__t_mfe_{int(_strategy_primary_h)}h"
+            _t_mae_col = f"__meta_raw__t_mae_{int(_strategy_primary_h)}h"
+            if all(
+                _c in df.columns for _c in [_mfe_col, _mae_col, _t_mfe_col, _t_mae_col]
+            ):
+                _native_exc = (
+                    np.asarray(df[_mfe_col].values, dtype=np.float32),
+                    np.asarray(df[_mae_col].values, dtype=np.float32),
+                    np.asarray(df[_t_mfe_col].values, dtype=np.float32),
+                    np.asarray(df[_t_mae_col].values, dtype=np.float32),
+                )
+            elif all(
+                _c in df.columns
+                for _c in ["__mfe_ret__", "__mae_ret__", "__t_mfe__", "__t_mae__"]
+            ):
+                _native_exc = (
+                    np.asarray(df["__mfe_ret__"].values, dtype=np.float32),
+                    np.asarray(df["__mae_ret__"].values, dtype=np.float32),
+                    np.asarray(df["__t_mfe__"].values, dtype=np.float32),
+                    np.asarray(df["__t_mae__"].values, dtype=np.float32),
+                )
+            _rank_mask_cache = cfg.setdefault("_meta_rank_mask_cache", {})
+            _mask_res = get_or_select_top_rank_mask(
+                strategy_id=str(k),
+                cache=_rank_mask_cache,
+                base_prob=_base_prob_vals,
+                strategy_mask=np.asarray(_trade_mask, dtype=bool),
+                symbols=_asset_vals,
+                timestamps=_ts_vals,
+                outcomes=_base_outcome,
+                mfe=_native_exc[0] if _native_exc is not None else None,
+                mae=_native_exc[1] if _native_exc is not None else None,
+                t_mfe=_native_exc[2] if _native_exc is not None else None,
+                t_mae=_native_exc[3] if _native_exc is not None else None,
+                tp=(
+                    np.asarray(df["__barrier_pct__"].values, dtype=np.float32)
+                    if "__barrier_pct__" in df.columns
+                    else np.full(len(df), 0.02, dtype=np.float32)
+                ),
+                topx_values=tuple(
+                    int(x)
+                    for x in cfg.get("meta_trade_topx_values", [20, 25, 30, 35, 40])
+                ),
+                rank_window=_rank_window,
+            )
+            _trade_mask = np.asarray(_trade_mask, dtype=bool) & np.asarray(
+                _mask_res.mask, dtype=bool
+            )
+            tprint(
+                f"  Meta {k}: rank-gated second mask chosen_topx={_mask_res.chosen_topx}% "
+                f"coverage={_mask_res.coverage:.4f} objective={_mask_res.score:.6e} "
+                f"kept={int(np.sum(_trade_mask))}/{len(_trade_mask)}"
             )
             _interaction_sources = {
                 "base_prob_x_compression_score": "compression_score",
@@ -13248,6 +13450,31 @@ def train_meta_models_from_artifacts(
             [c for c in meta_interaction_cols if c in X_meta_base.columns]
         )
         meta_model_cols = list(dict.fromkeys(meta_model_cols))
+        _ridge_test_keys = [
+            str(c)
+            for c in (cfg.get("test_feature_keys", []) or [])
+            if isinstance(c, str)
+        ]
+        if _ridge_test_keys:
+            _keep_preselected = set(_ridge_test_keys)
+            _keep_preselected.update(
+                {
+                    "base_model_score",
+                    "base_model_score_pct",
+                    "base_model_margin",
+                    "prob_error",
+                    "recent_prob_error_20",
+                    "recent_hit_rate_20",
+                    "base_model_abs_error_roll20",
+                }
+            )
+            _pre_n = len(meta_model_cols)
+            _filtered_cols = [c for c in meta_model_cols if c in _keep_preselected]
+            if _filtered_cols:
+                meta_model_cols = _filtered_cols
+                tprint(
+                    f"  Meta {k}: preselected ridge-test feature gate { _pre_n } -> {len(meta_model_cols)} cols"
+                )
         if not meta_model_cols:
             raise RuntimeError(
                 f"Meta {k}: no configured meta keys survived into the model input frame"
@@ -13391,6 +13618,7 @@ def train_meta_models_from_artifacts(
         w_meta_main = w_meta_main * _sign_consist
 
         # Fit bucket-level regressor only when explicitly enabled (default disabled).
+        _fit_mask_main = np.asarray(_trade_mask, dtype=bool)
         if include_meta_reg:
             meta_reg = MetaModel(reports_dir=reports_dir)
             meta_reg.strategy_name = _h_label
@@ -13474,6 +13702,7 @@ def train_meta_models_from_artifacts(
                 else np.full(len(df), 0.02, dtype=np.float32)
             )
             _y_reg = np.asarray(_meta_reg_target, dtype=np.float32)
+            _y_reg = np.where(np.asarray(_trade_mask, dtype=bool), _y_reg, np.nan)
             tprint(
                 f"  REG target: correction-on-base-reg H={_h_main} "
                 f"mean={float(np.mean(_y_reg)):.4f} std={float(np.std(_y_reg)):.4f} "
@@ -13481,12 +13710,16 @@ def train_meta_models_from_artifacts(
             )
             _y_bin_reg = _y_bin_for_h_aligned(int(_h_main))
             meta_reg.fit(
-                X_meta_models,
-                _y_reg,
-                sample_weight=w_meta_main,
-                groups=meta_groups,
+                X_meta_models.loc[_fit_mask_main].reset_index(drop=True),
+                np.asarray(_y_reg, dtype=float)[_fit_mask_main],
+                sample_weight=np.asarray(w_meta_main, dtype=float)[_fit_mask_main],
+                groups=(
+                    np.asarray(meta_groups)[_fit_mask_main]
+                    if meta_groups is not None
+                    else None
+                ),
                 y_per_horizon=None,
-                y_binary=_y_bin_reg,
+                y_binary=np.asarray(_y_bin_reg, dtype=float)[_fit_mask_main],
             )
             meta_models[_h_label] = meta_reg
             _bucket_y_ret[_h_label] = _y_reg.copy()
@@ -13503,6 +13736,9 @@ def train_meta_models_from_artifacts(
             )
             _y_q20_reg = np.where(np.isfinite(_y_q20_reg), _y_q20_reg, 0.0).astype(
                 np.float32
+            )
+            _y_q20_reg = np.where(
+                np.asarray(_trade_mask, dtype=bool), _y_q20_reg, np.nan
             )
             _q20_finite = np.isfinite(_ret_q20)
             _q20_thr = (
@@ -13533,10 +13769,14 @@ def train_meta_models_from_artifacts(
                     f"  Fitting MetaModel {k}_q20_reg (side-adjusted 20% tail, n={len(df)}, feats={X_meta_base.shape[1]}) ({_time.monotonic()-_t0_meta:.1f}s)..."
                 )
                 meta_q20_reg.fit(
-                    X_meta_models,
-                    _y_q20_reg,
-                    sample_weight=w_meta_main,
-                    groups=meta_groups,
+                    X_meta_models.loc[_fit_mask_main].reset_index(drop=True),
+                    np.asarray(_y_q20_reg, dtype=float)[_fit_mask_main],
+                    sample_weight=np.asarray(w_meta_main, dtype=float)[_fit_mask_main],
+                    groups=(
+                        np.asarray(meta_groups)[_fit_mask_main]
+                        if meta_groups is not None
+                        else None
+                    ),
                     y_per_horizon=None,
                 )
                 meta_models[f"{k}_q20_reg"] = meta_q20_reg
@@ -13801,6 +14041,7 @@ def train_meta_models_from_artifacts(
                     strategy=strat,
                 )
             w_meta_clf = w_meta_clf.astype(np.float32)
+            w_meta_clf = w_meta_clf * np.asarray(_trade_mask, dtype=np.float32)
 
             _mid_h = int(_strategy_primary_h)
             _move_vol_proxy = _vol_proxy
@@ -13933,17 +14174,28 @@ def train_meta_models_from_artifacts(
 
             try:
                 meta_clf.fit(
-                    X_meta_models,
-                    y_target_clf,
-                    sample_weight=w_meta_clf,
-                    groups=meta_groups,
-                    y_per_horizon=_y_per_h,
-                    vol_proxy=_move_vol_proxy,
-                    realized_u_policy=np.abs(y_target_clf),
+                    X_meta_models.loc[_fit_mask_main].reset_index(drop=True),
+                    np.asarray(y_target_clf, dtype=float)[_fit_mask_main],
+                    sample_weight=np.asarray(w_meta_clf, dtype=float)[_fit_mask_main],
+                    groups=(
+                        np.asarray(meta_groups)[_fit_mask_main]
+                        if meta_groups is not None
+                        else None
+                    ),
+                    y_per_horizon={
+                        int(h): np.asarray(v, dtype=float)[_fit_mask_main]
+                        for h, v in _y_per_h.items()
+                    },
+                    vol_proxy=np.asarray(_move_vol_proxy, dtype=float)[_fit_mask_main],
+                    realized_u_policy=np.abs(np.asarray(y_target_clf, dtype=float))[
+                        _fit_mask_main
+                    ],
                     selection_cfg=_sel_cfg,
-                    y_move_override=_y_move_soft,
-                    y_class_override=_y_move,
-                    trade_mask=_trade_mask,
+                    y_move_override=np.asarray(_y_move_soft, dtype=float)[
+                        _fit_mask_main
+                    ],
+                    y_class_override=np.asarray(_y_move, dtype=float)[_fit_mask_main],
+                    trade_mask=np.asarray(_trade_mask, dtype=bool)[_fit_mask_main],
                     move_thresholds=_move_thresholds,
                     move_weights=_move_weights,
                     use_class_weight_multiplier=bool(
@@ -14023,17 +14275,34 @@ def train_meta_models_from_artifacts(
                         require_positive_base_rate=False,
                     )
                     _meta_clf_fallback.fit(
-                        X_meta_models,
-                        y_target_clf,
-                        sample_weight=w_meta_clf,
-                        groups=meta_groups,
-                        y_per_horizon=_y_per_h,
-                        vol_proxy=_move_vol_proxy,
-                        realized_u_policy=np.abs(y_target_clf),
+                        X_meta_models.loc[_fit_mask_main].reset_index(drop=True),
+                        np.asarray(y_target_clf, dtype=float)[_fit_mask_main],
+                        sample_weight=np.asarray(w_meta_clf, dtype=float)[
+                            _fit_mask_main
+                        ],
+                        groups=(
+                            np.asarray(meta_groups)[_fit_mask_main]
+                            if meta_groups is not None
+                            else None
+                        ),
+                        y_per_horizon={
+                            int(h): np.asarray(v, dtype=float)[_fit_mask_main]
+                            for h, v in _y_per_h.items()
+                        },
+                        vol_proxy=np.asarray(_move_vol_proxy, dtype=float)[
+                            _fit_mask_main
+                        ],
+                        realized_u_policy=np.abs(np.asarray(y_target_clf, dtype=float))[
+                            _fit_mask_main
+                        ],
                         selection_cfg=_sel_cfg_fallback,
-                        y_move_override=_y_move_soft,
-                        y_class_override=_y_move,
-                        trade_mask=_trade_mask,
+                        y_move_override=np.asarray(_y_move_soft, dtype=float)[
+                            _fit_mask_main
+                        ],
+                        y_class_override=np.asarray(_y_move, dtype=float)[
+                            _fit_mask_main
+                        ],
+                        trade_mask=np.asarray(_trade_mask, dtype=bool)[_fit_mask_main],
                         move_thresholds=_move_thresholds,
                         move_weights=_move_weights,
                         use_class_weight_multiplier=False,
@@ -14087,6 +14356,7 @@ def train_meta_models_from_artifacts(
                 _cal_target = _build_base_correctness_target_for_h(int(_mid_h))
                 _cal_residual = np.asarray(_cal_target["residual"], dtype=np.float32)
                 _cal_valid = np.asarray(_cal_target["valid_mask"], dtype=bool)
+                _cal_valid &= np.asarray(_trade_mask, dtype=bool)
                 _cal_confidence = np.asarray(
                     _cal_target["confidence"], dtype=np.float32
                 )
@@ -14262,16 +14532,31 @@ def train_meta_models_from_artifacts(
                 meta_q20_clf.FEE_PER_ROUND_TRIP = _meta_clf_fee
                 try:
                     meta_q20_clf.fit(
-                        X_meta_models,
-                        _ret_q20,
-                        sample_weight=w_meta_clf,
-                        groups=meta_groups,
-                        y_per_horizon=_y_per_h,
-                        vol_proxy=_move_vol_proxy,
-                        realized_u_policy=np.abs(_ret_q20),
+                        X_meta_models.loc[_fit_mask_main].reset_index(drop=True),
+                        np.asarray(_ret_q20, dtype=float)[_fit_mask_main],
+                        sample_weight=np.asarray(w_meta_clf, dtype=float)[
+                            _fit_mask_main
+                        ],
+                        groups=(
+                            np.asarray(meta_groups)[_fit_mask_main]
+                            if meta_groups is not None
+                            else None
+                        ),
+                        y_per_horizon={
+                            int(h): np.asarray(v, dtype=float)[_fit_mask_main]
+                            for h, v in _y_per_h.items()
+                        },
+                        vol_proxy=np.asarray(_move_vol_proxy, dtype=float)[
+                            _fit_mask_main
+                        ],
+                        realized_u_policy=np.abs(np.asarray(_ret_q20, dtype=float))[
+                            _fit_mask_main
+                        ],
                         selection_cfg=_sel_cfg,
-                        y_class_override=_y_q20_clf,
-                        trade_mask=_trade_mask,
+                        y_class_override=np.asarray(_y_q20_clf, dtype=float)[
+                            _fit_mask_main
+                        ],
+                        trade_mask=np.asarray(_trade_mask, dtype=bool)[_fit_mask_main],
                         move_thresholds=_move_thresholds,
                         move_weights=_move_weights,
                         use_class_weight_multiplier=bool(


### PR DESCRIPTION
### Motivation
- Introduce an ElasticNet-based uncertainty combiner to improve/adjust base OOF predictions using tree-based uncertainty features and guardrails. 
- Provide a reusable top-rank trade gating mechanism that selects high-quality top-x% trades per asset via a causal rolling percentile, enabling rank-gating of training and sizing flows.

### Description
- Added `en_based_uncertainty_features_selection.py`, an ElasticNet combiner that assembles uncertainty features, prunes and selects features, evaluates candidates across alpha/L1 grids, produces OOFs and saves processing artifacts and model bundles.
- Added `meta_training/trade_filtering.py` implementing `rolling_asset_percentile` and `select_top_rank_mask` (and `get_or_select_top_rank_mask` caching) that compute causal per-asset percentile ranks and choose an optimal top-x mask using lift/coverage/excess magnitude objective.
- Integrated the new modules into the pipeline: `pipeline_steps.py` now calls the EN combiner post-training and includes small robustness/formatting fixes and safe imports; `simple_position_sizer.py` applies the top-rank mask to prune candidate trades before sizing; `training.py` computes and exposes base-model rank/pct/error features, obtains a cached rank mask via `get_or_select_top_rank_mask`, and uses that mask to gate training rows (many training fits now use a `_fit_mask` derived from `_trade_mask`).
- Miscellaneous: numerous defensive and formatting tweaks across feature injection, HPO/MDI feature selection callers, DataFrame handling (tz/localization), and small API/parameter unwrapping to ensure compatibility with the new features.

### Testing
- Ran the repository test-suite with `pytest -q` (unit tests completed successfully). 
- Executed smoke/integration runs of the affected pipeline entry points (`run_training_step` / meta training path and the simple sizer flow) on a small synthetic/sample artifact set to verify the EN combiner and top-rank gating execute without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c49d78c4832f821d2cd8d8d8c886)