### PR TITLE
Add weak-residual meta learners and Ridge-on-LGBM model; integrate into meta training

### DIFF
--- a/extreme_price_movements/ridge_on_lgbm.py
+++ b/extreme_price_movements/ridge_on_lgbm.py
@@ -1,0 +1,996 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from scipy import sparse
+from scipy.stats import rankdata
+from sklearn.linear_model import LogisticRegression, RidgeClassifier
+from sklearn.metrics import average_precision_score, brier_score_loss, roc_auc_score
+from sklearn.model_selection import StratifiedKFold, train_test_split
+from sklearn.preprocessing import OneHotEncoder, RobustScaler
+
+try:
+    import lightgbm as lgb
+except Exception:  # pragma: no cover
+    lgb = None
+
+ALPHA_GRID = (0.05, 0.2, 0.5, 1.0)
+L1_RATIO_GRID = (0.6, 0.8, 0.9, 0.95)
+LEAF_MODEL_SPECS = (
+    {"max_depth": 3, "leaf_frac": 0.02, "prefix": "LGBM_2P_LEAF"},
+    {"max_depth": 3, "leaf_frac": 0.04, "prefix": "LGBM_4P_LEAF"},
+    {"max_depth": 3, "leaf_frac": 0.06, "prefix": "LGBM_6P_LEAF"},
+    {"max_depth": 3, "leaf_frac": 0.08, "prefix": "LGBM_8P_LEAF"},
+    {"max_depth": 4, "leaf_frac": 0.02, "prefix": "LGBM_D4_2P_LEAF"},
+    {"max_depth": 4, "leaf_frac": 0.05, "prefix": "LGBM_D4_5P_LEAF"},
+)
+
+
+def _make_onehot_encoder() -> OneHotEncoder:
+    try:
+        return OneHotEncoder(handle_unknown="ignore", sparse_output=True)
+    except TypeError:  # pragma: no cover - sklearn compatibility
+        return OneHotEncoder(handle_unknown="ignore", sparse=True)
+
+
+def _stratified_subsample_indices(
+    y: np.ndarray, max_n: int = 15000, random_state: int = 42
+) -> np.ndarray:
+    y_arr = np.asarray(y, dtype=np.int8)
+    idx_all = np.arange(len(y_arr), dtype=np.int32)
+    if len(y_arr) <= max_n:
+        return idx_all
+    idx_sub, _ = train_test_split(
+        idx_all,
+        train_size=max_n,
+        stratify=y_arr,
+        random_state=random_state,
+    )
+    return np.asarray(idx_sub, dtype=np.int32)
+
+
+def top30_boundary_weight(pred: np.ndarray) -> np.ndarray:
+    rank_pct = (
+        pd.Series(np.asarray(pred, dtype=np.float32))
+        .rank(pct=True)
+        .to_numpy(dtype=np.float32)
+    )
+    center = 0.75
+    sigma = 0.10
+    boundary = np.exp(-((rank_pct - center) ** 2) / (2 * sigma**2))
+    topness = np.clip((rank_pct - 0.70) / 0.30, 0.0, 1.0)
+    w = 1.0 + 1.5 * boundary + 0.5 * topness
+    return np.clip(w, 1.0, 3.0).astype(np.float32)
+
+
+def _expected_calibration_error(
+    y_true: np.ndarray, pred: np.ndarray, n_bins: int = 10
+) -> float:
+    y = np.asarray(y_true, dtype=np.float32)
+    p = np.asarray(pred, dtype=np.float32)
+    if len(y) == 0:
+        return 0.0
+    p = np.clip(p, 1e-6, 1.0 - 1e-6)
+    bins = np.linspace(0.0, 1.0, n_bins + 1)
+    ece = 0.0
+    for i in range(n_bins):
+        lo = bins[i]
+        hi = bins[i + 1]
+        if i < n_bins - 1:
+            mask = (p >= lo) & (p < hi)
+        else:
+            mask = (p >= lo) & (p <= hi)
+        if np.any(mask):
+            acc = float(np.mean(y[mask]))
+            conf = float(np.mean(p[mask]))
+            ece += (float(np.sum(mask)) / float(len(y))) * abs(acc - conf)
+    return float(ece)
+
+
+def _metric_pack(y_true: np.ndarray, pred: np.ndarray) -> dict[str, float]:
+    y = np.asarray(y_true, dtype=np.int8)
+    p = np.asarray(pred, dtype=np.float64)
+    k = max(1, int(0.30 * len(y)))
+    idx = np.argsort(p)[-k:]
+    top_rate = float(np.mean(y[idx])) if len(idx) else 0.0
+    base_rate = float(np.mean(y)) if len(y) else 0.0
+    lift30 = top_rate / max(base_rate, 1e-6)
+    auc_correct_30 = 0.5
+    if len(np.unique(y[idx])) > 1:
+        try:
+            auc_correct_30 = float(roc_auc_score(y[idx], p[idx]))
+        except Exception:
+            auc_correct_30 = 0.5
+
+    q = np.quantile(p[idx], np.linspace(0, 1, 6)) if len(idx) >= 10 else None
+    if q is None:
+        stability30_proxy = 0.0
+    else:
+        vals = []
+        sp = p[idx]
+        sy = y[idx]
+        for i in range(5):
+            m = (sp >= q[i]) & (sp < q[i + 1] if i < 4 else sp <= q[i + 1])
+            if np.any(m):
+                vals.append(float(np.mean(sy[m])))
+        stability30_proxy = float(1.0 / (1.0 + np.std(vals))) if vals else 0.0
+
+    auc = float(roc_auc_score(y, p)) if len(np.unique(y)) > 1 else 0.5
+    auc_random = auc / 0.5
+    pr = float(average_precision_score(y, p)) if len(np.unique(y)) > 1 else base_rate
+    pr_rand = pr / max(base_rate, 1e-6)
+    brier = float(brier_score_loss(y, np.clip(p, 1e-6, 1 - 1e-6)))
+    ece = _expected_calibration_error(y, p)
+    return {
+        "lift30": lift30,
+        "auc_correct_30": auc_correct_30,
+        "stability30_proxy": stability30_proxy,
+        "auc": auc,
+        "auc_random": auc_random,
+        "pr_auc": pr,
+        "pr_random": pr_rand,
+        "brier": brier,
+        "ece": ece,
+        "top30_correctness_rate": top_rate,
+        "overall_correctness_rate": base_rate,
+        "oof_std": float(np.std(p)),
+    }
+
+
+def _fold_j(metrics: dict[str, float]) -> float:
+    return 0.6 * float(metrics["lift30"]) + 0.4 * float(metrics["auc_correct_30"])
+
+
+def _aggregate_j(fold_metrics: list[dict[str, float]]) -> dict[str, float]:
+    if not fold_metrics:
+        return {
+            "lift30": 0.0,
+            "auc_correct_30": 0.0,
+            "stability30": 0.0,
+            "J_mean": 0.0,
+            "J_std": 0.0,
+            "J_final": 0.0,
+        }
+
+    lift30 = float(np.mean([m["lift30"] for m in fold_metrics]))
+    auc_correct_30 = float(np.mean([m["auc_correct_30"] for m in fold_metrics]))
+    j_vals = np.array([_fold_j(m) for m in fold_metrics], dtype=float)
+    stability30 = float(np.mean(j_vals) - 2.0 * np.std(j_vals))
+    j_final = 0.4 * lift30 + 0.2 * auc_correct_30 + 0.4 * stability30
+
+    return {
+        "lift30": lift30,
+        "auc_correct_30": auc_correct_30,
+        "stability30": stability30,
+        "J_mean": float(np.mean(j_vals)),
+        "J_std": float(np.std(j_vals)),
+        "J_final": float(j_final),
+    }
+
+
+def _pruning_thresholds(round_id: int) -> tuple[float, float]:
+    if round_id <= 2:
+        return 0.60, 0.20
+    if round_id <= 4:
+        return 0.70, 0.30
+    return 0.80, 0.40
+
+
+def _floor_keep(round_id: int, current_feature_count: int) -> int:
+    floor_schedule = {1: 0.80, 2: 0.70, 3: 0.60, 4: 0.50, 5: 0.40, 6: 0.30, 7: 0.20}
+    frac = float(floor_schedule.get(round_id, 0.20))
+    return int(
+        min(current_feature_count, max(40, np.ceil(frac * current_feature_count)))
+    )
+
+
+def _point_line_distance(px, py, x1, y1, x2, y2) -> float:
+    dx = x2 - x1
+    dy = y2 - y1
+    if abs(dx) < 1e-12 and abs(dy) < 1e-12:
+        return float(np.sqrt((px - x1) ** 2 + (py - y1) ** 2))
+    return float(
+        abs(dy * px - dx * py + x2 * y1 - y2 * x1) / np.sqrt(dx * dx + dy * dy)
+    )
+
+
+def _pareto_frontier(cands: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out = []
+    for i, a in enumerate(cands):
+        dominated = False
+        for j, b in enumerate(cands):
+            if i == j:
+                continue
+            if (
+                float(b["J_final"]) >= float(a["J_final"])
+                and float(b["stability30"]) >= float(a["stability30"])
+                and (
+                    float(b["J_final"]) > float(a["J_final"])
+                    or float(b["stability30"]) > float(a["stability30"])
+                )
+            ):
+                dominated = True
+                break
+        if not dominated:
+            out.append(a)
+    return out
+
+
+def _select_elbow_candidate(frontier: list[dict[str, Any]]) -> dict[str, Any]:
+    if len(frontier) == 1:
+        return frontier[0]
+    if len(frontier) == 2:
+        return sorted(frontier, key=lambda z: float(z["J_final"]))[-1]
+
+    perf = np.array([float(c["J_final"]) for c in frontier], dtype=float)
+    stab = np.array([float(c["stability30"]) for c in frontier], dtype=float)
+    perf_n = (perf - float(np.min(perf))) / max(
+        float(np.max(perf) - np.min(perf)), 1e-12
+    )
+    stab_n = (stab - float(np.min(stab))) / max(
+        float(np.max(stab) - np.min(stab)), 1e-12
+    )
+
+    order = np.argsort(perf_n)
+    perf_n = perf_n[order]
+    stab_n = stab_n[order]
+    frontier_sorted = [frontier[i] for i in order]
+
+    x1, y1 = float(perf_n[0]), float(stab_n[0])
+    x2, y2 = float(perf_n[-1]), float(stab_n[-1])
+    dists = np.array(
+        [
+            _point_line_distance(float(px), float(py), x1, y1, x2, y2)
+            for px, py in zip(perf_n, stab_n)
+        ],
+        dtype=float,
+    )
+    best_idx = int(np.argmax(dists))
+    return frontier_sorted[best_idx]
+
+
+def _quick_cv_score(
+    x_sel: sparse.csr_matrix,
+    y: np.ndarray,
+    random_state: int,
+    alpha: float,
+    l1_ratio: float,
+    prior_round_pred: np.ndarray | None = None,
+) -> dict[str, float]:
+    y_arr = np.asarray(y, dtype=np.int8)
+    prior = (
+        np.asarray(prior_round_pred, dtype=np.float32)
+        if prior_round_pred is not None
+        else np.full(len(y_arr), float(np.mean(y_arr)), dtype=np.float32)
+    )
+    w = top30_boundary_weight(prior)
+    cv = StratifiedKFold(n_splits=3, shuffle=True, random_state=random_state)
+    fold_metrics: list[dict[str, float]] = []
+    for tr_idx, va_idx in cv.split(np.zeros(len(y_arr), dtype=np.int8), y_arr):
+        x_tr = x_sel[tr_idx]
+        y_tr = y_arr[tr_idx]
+        w_tr = w[tr_idx]
+        sub_idx = _stratified_subsample_indices(
+            y_tr, max_n=15000, random_state=random_state
+        )
+        lr = LogisticRegression(
+            penalty="elasticnet",
+            solver="saga",
+            max_iter=2000,
+            C=1.0 / max(alpha, 1e-6),
+            l1_ratio=float(l1_ratio),
+            random_state=random_state,
+        )
+        lr.fit(x_tr[sub_idx], y_tr[sub_idx], sample_weight=w_tr[sub_idx])
+        pv = lr.predict_proba(x_sel[va_idx])[:, 1]
+        fold_metrics.append(_metric_pack(y_arr[va_idx], pv))
+    return _aggregate_j(fold_metrics)
+
+
+def _feature_abs_spearman_scores(
+    x_mat: sparse.csr_matrix,
+    y: np.ndarray,
+    feat_idx: np.ndarray,
+    row_idx: np.ndarray,
+) -> np.ndarray:
+    x = np.asarray(x_mat[row_idx][:, feat_idx].toarray(), dtype=np.float32)
+    y_s = np.asarray(y[row_idx], dtype=np.float32)
+    if x.size == 0:
+        return np.zeros(len(feat_idx), dtype=np.float32)
+    x_rank = np.argsort(np.argsort(x, axis=0), axis=0).astype(np.float32)
+    y_rank = rankdata(y_s, method="average").astype(np.float32)
+    x_rank -= np.mean(x_rank, axis=0, keepdims=True)
+    y_rank -= np.mean(y_rank)
+    x_std = np.std(x_rank, axis=0) + 1e-12
+    y_std = float(np.std(y_rank) + 1e-12)
+    corr = np.mean(x_rank * y_rank.reshape(-1, 1), axis=0) / (x_std * y_std)
+    corr = np.nan_to_num(corr, nan=0.0, posinf=0.0, neginf=0.0)
+    return np.abs(corr).astype(np.float32)
+
+
+def _greedy_drop_from_pairs(
+    n_feats: int, pairs: np.ndarray, col_strength: np.ndarray
+) -> np.ndarray:
+    keep = np.ones(n_feats, dtype=bool)
+    if len(pairs) == 0:
+        return keep
+    for i, j in pairs:
+        if not (keep[i] and keep[j]):
+            continue
+        if col_strength[i] <= col_strength[j]:
+            keep[j] = False
+        else:
+            keep[i] = False
+    return keep
+
+
+def _prune_raw_redundancy(
+    x_mat: sparse.csr_matrix,
+    feat_idx: np.ndarray,
+    row_idx: np.ndarray,
+    threshold: float,
+) -> np.ndarray:
+    if len(feat_idx) <= 1:
+        return feat_idx
+    x = np.asarray(x_mat[row_idx][:, feat_idx].toarray(), dtype=np.float32)
+    x_rank = np.argsort(np.argsort(x, axis=0), axis=0).astype(np.float32)
+    corr = np.abs(np.corrcoef(x_rank, rowvar=False))
+    corr = np.nan_to_num(corr, nan=0.0)
+    upper = np.triu(corr > threshold, k=1)
+    pairs = np.column_stack(np.where(upper))
+    strength = np.sum(corr, axis=0)
+    keep_mask = _greedy_drop_from_pairs(len(feat_idx), pairs, strength)
+    return feat_idx[keep_mask]
+
+
+def _prune_leaf_overlap_redundancy(
+    x_mat: sparse.csr_matrix,
+    feat_idx: np.ndarray,
+    row_idx: np.ndarray,
+    threshold: float,
+) -> np.ndarray:
+    if len(feat_idx) <= 1:
+        return feat_idx
+    x = x_mat[row_idx][:, feat_idx].copy().astype(np.int8)
+    x.data = np.ones_like(x.data, dtype=np.int8)
+    supports = np.asarray(x.sum(axis=0)).reshape(-1).astype(np.float32)
+    inter = (x.T @ x).tocoo()
+    valid = inter.row < inter.col
+    rows = inter.row[valid]
+    cols = inter.col[valid]
+    vals = inter.data[valid].astype(np.float32)
+    denom = np.minimum(supports[rows], supports[cols]) + 1e-12
+    overlap = vals / denom
+    sel = overlap > threshold
+    pairs = np.column_stack([rows[sel], cols[sel]])
+    keep_mask = _greedy_drop_from_pairs(len(feat_idx), pairs, supports)
+    return feat_idx[keep_mask]
+
+
+def _non_overlapping_stratified_buckets(
+    y: np.ndarray, n_buckets: int = 5, bucket_size: int = 3000, random_state: int = 42
+) -> list[np.ndarray]:
+    rng = np.random.RandomState(random_state)
+    y_arr = np.asarray(y, dtype=np.int8)
+    pos = np.where(y_arr == 1)[0]
+    neg = np.where(y_arr == 0)[0]
+    rng.shuffle(pos)
+    rng.shuffle(neg)
+    p_ratio = float(np.mean(y_arr))
+    n_pos_each = int(min(len(pos) // n_buckets, max(1, round(bucket_size * p_ratio))))
+    n_neg_each = int(min(len(neg) // n_buckets, max(1, bucket_size - n_pos_each)))
+    buckets: list[np.ndarray] = []
+    p_ptr = 0
+    n_ptr = 0
+    for _ in range(n_buckets):
+        p_take = pos[p_ptr : p_ptr + n_pos_each]
+        n_take = neg[n_ptr : n_ptr + n_neg_each]
+        p_ptr += len(p_take)
+        n_ptr += len(n_take)
+        if len(p_take) + len(n_take) == 0:
+            continue
+        b = np.concatenate([p_take, n_take]).astype(np.int32, copy=False)
+        rng.shuffle(b)
+        buckets.append(b)
+    return buckets
+
+
+def _prescreen_features(
+    x_mat: sparse.csr_matrix,
+    y: np.ndarray,
+    feat_idx: np.ndarray,
+    random_state: int,
+    n_raw_total: int,
+) -> np.ndarray:
+    n_total = len(feat_idx)
+    if n_total <= 600:
+        return feat_idx
+    row_idx_redund = _stratified_subsample_indices(
+        y, max_n=min(3000, len(y)), random_state=random_state + 5
+    )
+    raw_mask = feat_idx < n_raw_total
+    leaf_mask = ~raw_mask
+    feat_raw = feat_idx[raw_mask]
+    feat_leaf = feat_idx[leaf_mask]
+    feat_raw = _prune_raw_redundancy(x_mat, feat_raw, row_idx_redund, threshold=0.98)
+    feat_leaf = _prune_leaf_overlap_redundancy(
+        x_mat, feat_leaf, row_idx_redund, threshold=0.98
+    )
+    feat_idx = np.concatenate([feat_raw, feat_leaf]).astype(np.int32, copy=False)
+    if len(feat_idx) <= 600:
+        return feat_idx
+    row_idx_stage1 = _stratified_subsample_indices(
+        y, max_n=min(5000, len(y)), random_state=random_state
+    )
+    scores_1 = _feature_abs_spearman_scores(x_mat, y, feat_idx, row_idx_stage1)
+    nkept1 = min(n_total, max(600, int(0.25 * n_total + 200)))
+    top1 = np.argsort(scores_1)[-nkept1:]
+    feat_stage1 = feat_idx[top1]
+    raw_mask_1 = feat_stage1 < n_raw_total
+    leaf_mask_1 = ~raw_mask_1
+    feat_raw_1 = _prune_raw_redundancy(
+        x_mat, feat_stage1[raw_mask_1], row_idx_stage1, threshold=0.97
+    )
+    feat_leaf_1 = _prune_leaf_overlap_redundancy(
+        x_mat, feat_stage1[leaf_mask_1], row_idx_stage1, threshold=0.97
+    )
+    feat_stage1 = np.concatenate([feat_raw_1, feat_leaf_1]).astype(np.int32, copy=False)
+    n1 = len(feat_stage1)
+    if n1 <= 1:
+        return feat_stage1
+
+    buckets = _non_overlapping_stratified_buckets(
+        y, n_buckets=5, bucket_size=3000, random_state=random_state + 17
+    )
+    if len(buckets) == 0:
+        return feat_stage1
+    bucket_scores = np.zeros((len(buckets), n1), dtype=np.float32)
+    for b_i, b_idx in enumerate(buckets):
+        b_idx = b_idx[: min(len(b_idx), 3000)]
+        bucket_scores[b_i] = _feature_abs_spearman_scores(x_mat, y, feat_stage1, b_idx)
+    mean_score = np.mean(bucket_scores, axis=0)
+    std_score = np.std(bucket_scores, axis=0)
+    stable_score = mean_score - 0.5 * std_score
+    nkept2 = min(n1, max(1, int(0.25 * n1 + 100)))
+    top2 = np.argsort(stable_score)[-nkept2:]
+    return feat_stage1[top2]
+
+
+def _stage_a_prune(
+    X_combined: sparse.csr_matrix,
+    y: np.ndarray,
+    random_state: int,
+    n_raw_total: int,
+    prior_round_pred: np.ndarray | None,
+    initial_features: np.ndarray | None = None,
+    max_rounds: int = 7,
+) -> dict[str, Any]:
+    y_arr = np.asarray(y, dtype=np.int8)
+    n = len(y_arr)
+    active_idx = (
+        np.asarray(initial_features, dtype=np.int32)
+        if initial_features is not None
+        else np.arange(X_combined.shape[1], dtype=np.int32)
+    )
+    active_idx = _prescreen_features(
+        X_combined,
+        y_arr,
+        active_idx,
+        random_state=random_state,
+        n_raw_total=n_raw_total,
+    )
+
+    round_history: list[dict[str, Any]] = []
+    last_round_oof = (
+        np.asarray(prior_round_pred, dtype=np.float32)
+        if prior_round_pred is not None
+        else np.full(n, float(np.mean(y_arr)), dtype=np.float32)
+    )
+
+    golden_floor_score = None
+    golden_floor_se = None
+
+    for round_id in range(1, max_rounds + 1):
+        if len(active_idx) <= 40:
+            break
+        prev_active_idx = np.asarray(active_idx, dtype=np.int32).copy()
+        prev_round_oof = np.asarray(last_round_oof, dtype=np.float32).copy()
+        min_freq, min_net_support = _pruning_thresholds(round_id)
+        x_round = X_combined[:, active_idx]
+        w_round = top30_boundary_weight(last_round_oof)
+
+        fold_cv = StratifiedKFold(
+            n_splits=3, shuffle=True, random_state=random_state + round_id
+        )
+        hp_records: list[dict[str, Any]] = []
+
+        for alpha in ALPHA_GRID:
+            for l1_ratio in L1_RATIO_GRID:
+                fold_coefs: list[np.ndarray] = []
+                fold_metrics: list[dict[str, float]] = []
+                round_oof = np.zeros(n, dtype=np.float32)
+                ok = True
+                for tr_idx, va_idx in fold_cv.split(np.zeros(n, dtype=np.int8), y_arr):
+                    x_tr = x_round[tr_idx]
+                    y_tr = y_arr[tr_idx]
+                    w_tr = w_round[tr_idx]
+                    sub_idx = _stratified_subsample_indices(
+                        y_tr, max_n=15000, random_state=random_state + round_id
+                    )
+                    lr = LogisticRegression(
+                        penalty="elasticnet",
+                        solver="saga",
+                        max_iter=3000,
+                        C=1.0 / max(alpha, 1e-6),
+                        l1_ratio=float(l1_ratio),
+                        random_state=random_state,
+                    )
+                    try:
+                        lr.fit(
+                            x_tr[sub_idx], y_tr[sub_idx], sample_weight=w_tr[sub_idx]
+                        )
+                        pv = lr.predict_proba(x_round[va_idx])[:, 1]
+                    except Exception:
+                        ok = False
+                        break
+                    round_oof[va_idx] = pv.astype(np.float32)
+                    fold_metrics.append(_metric_pack(y_arr[va_idx], pv))
+                    fold_coefs.append(lr.coef_.reshape(-1).astype(np.float32))
+                if not ok or len(fold_metrics) == 0:
+                    continue
+
+                agg = _aggregate_j(fold_metrics)
+                hp_records.append(
+                    {
+                        "alpha": float(alpha),
+                        "l1_ratio": float(l1_ratio),
+                        "oof": round_oof,
+                        "fold_coefs": fold_coefs,
+                        "fold_metrics": fold_metrics,
+                        "lift30": float(agg["lift30"]),
+                        "auc_correct_30": float(agg["auc_correct_30"]),
+                        "stability30": float(agg["stability30"]),
+                        "J_mean": float(agg["J_mean"]),
+                        "J_std": float(agg["J_std"]),
+                        "J_final": float(agg["J_final"]),
+                    }
+                )
+
+        if len(hp_records) == 0:
+            break
+
+        best = max(hp_records, key=lambda z: float(z["J_final"]))
+        all_scores = np.array([float(r["J_final"]) for r in hp_records], dtype=float)
+        best_se = (
+            float(np.std(all_scores, ddof=1) / max(np.sqrt(len(all_scores)), 1.0))
+            if len(all_scores) > 1
+            else 0.0
+        )
+        score_cut = float(best["J_final"]) - best_se
+        contenders = [z for z in hp_records if float(z["J_final"]) >= score_cut]
+
+        frontier = _pareto_frontier(contenders)
+        print(f"Frontier Analysis: {len(frontier)} non-dominated candidates found.")
+        chosen = _select_elbow_candidate(frontier)
+        print(
+            f"Selected 'Elbow' candidate: Alpha={chosen['alpha']}, "
+            f"L1={chosen['l1_ratio']}, Features={len(active_idx)}."
+        )
+
+        pooled_coef = np.vstack(
+            [coef for cand in contenders for coef in cand["fold_coefs"]]
+        )
+        total_models_in_pool = max(1, pooled_coef.shape[0])
+        active_freq = np.mean(np.abs(pooled_coef) > 1e-6, axis=0)
+        pos = np.sum(pooled_coef > 1e-6, axis=0)
+        neg = np.sum(pooled_coef < -1e-6, axis=0)
+        net_support = np.abs(pos - neg) / float(total_models_in_pool)
+        keep_mask = (active_freq >= min_freq) & (net_support >= min_net_support)
+        floor_keep = _floor_keep(round_id, len(active_idx))
+        if int(np.sum(keep_mask)) < floor_keep:
+            rank_score = active_freq * np.maximum(net_support, 1e-8)
+            top_k = min(len(rank_score), floor_keep)
+            keep_mask = np.zeros(len(rank_score), dtype=bool)
+            keep_mask[np.argsort(rank_score)[-top_k:]] = True
+        if int(np.sum(keep_mask)) < 40:
+            break
+
+        candidate_active = active_idx[np.asarray(keep_mask, dtype=bool)]
+        candidate_oof = np.asarray(chosen["oof"], dtype=np.float32)
+
+        if round_id == 1:
+            golden_floor_score = float(best["J_final"])
+            golden_floor_se = float(best_se)
+        else:
+            quick = _quick_cv_score(
+                X_combined[:, candidate_active],
+                y_arr,
+                random_state=random_state + round_id,
+                alpha=float(chosen["alpha"]),
+                l1_ratio=float(chosen["l1_ratio"]),
+                prior_round_pred=candidate_oof,
+            )
+            if (
+                golden_floor_score is not None
+                and golden_floor_se is not None
+                and float(quick["J_final"])
+                < float(golden_floor_score - golden_floor_se)
+            ):
+                round_history.append(
+                    {
+                        "round": round_id,
+                        "stopped_by_golden_floor": True,
+                        "candidate_J_final": float(quick["J_final"]),
+                        "golden_floor_score": float(golden_floor_score),
+                        "golden_floor_se": float(golden_floor_se),
+                    }
+                )
+                active_idx = prev_active_idx
+                last_round_oof = prev_round_oof
+                break
+
+        active_idx = candidate_active
+        last_round_oof = candidate_oof
+        round_history.append(
+            {
+                "round": round_id,
+                "n_features_start": int(x_round.shape[1]),
+                "n_features_end": int(len(active_idx)),
+                "alpha": float(chosen["alpha"]),
+                "l1_ratio": float(chosen["l1_ratio"]),
+                "J_final": float(chosen["J_final"]),
+                "J_mean": float(chosen["J_mean"]),
+                "J_std": float(chosen["J_std"]),
+                "stability30": float(chosen["stability30"]),
+                "min_freq": float(min_freq),
+                "min_net_support": float(min_net_support),
+                "floor_keep": int(floor_keep),
+                "active_freq_mean": float(np.mean(active_freq)),
+                "net_support_mean": float(np.mean(net_support)),
+            }
+        )
+
+    return {
+        "selected_indices": np.asarray(active_idx, dtype=np.int32),
+        "pruning_history": round_history,
+        "last_round_en_oof": np.asarray(last_round_oof, dtype=np.float32),
+    }
+
+
+def _fit_lgbm_leaf_bundle(
+    x_train: np.ndarray,
+    y_train: np.ndarray,
+    x_eval: np.ndarray,
+    y_eval: np.ndarray | None,
+    random_state: int,
+) -> dict[str, Any]:
+    models = []
+    encoders = []
+    train_leaf_parts = []
+    eval_leaf_parts = []
+    leaf_feature_names: list[str] = []
+
+    for spec in LEAF_MODEL_SPECS:
+        leaf_frac = float(spec["leaf_frac"])
+        prefix = str(spec["prefix"])
+        max_depth = int(spec["max_depth"])
+        lgbm = lgb.LGBMClassifier(
+            objective="binary",
+            learning_rate=0.05,
+            max_depth=max_depth,
+            min_data_in_leaf=max(50, int(leaf_frac * len(x_train))),
+            min_sum_hessian_in_leaf=1e-3,
+            feature_fraction=0.7,
+            bagging_fraction=0.8,
+            bagging_freq=1,
+            lambda_l2=5.0,
+            min_gain_to_split=0.001,
+            max_bin=127,
+            n_estimators=500,
+            n_jobs=2,
+        )
+        fit_idx = _stratified_subsample_indices(
+            y_train, max_n=15000, random_state=random_state
+        )
+        fit_kwargs = {}
+        if y_eval is not None:
+            fit_kwargs = {
+                "eval_set": [(x_eval, y_eval)],
+                "callbacks": [lgb.early_stopping(25, verbose=False)],
+            }
+        lgbm.fit(x_train[fit_idx], y_train[fit_idx], **fit_kwargs)
+
+        leaf_train = lgbm.predict(x_train, pred_leaf=True)
+        leaf_eval = lgbm.predict(x_eval, pred_leaf=True)
+        enc = _make_onehot_encoder()
+        enc.fit(leaf_train)
+        train_part = enc.transform(leaf_train)
+        eval_part = enc.transform(leaf_eval)
+        n_cols = int(train_part.shape[1])
+        leaf_feature_names.extend([f"{prefix}_{i}" for i in range(n_cols)])
+        models.append(lgbm)
+        encoders.append(enc)
+        train_leaf_parts.append(train_part)
+        eval_leaf_parts.append(eval_part)
+
+    train_leaf_matrix = sparse.hstack(train_leaf_parts, format="csr")
+    eval_leaf_matrix = sparse.hstack(eval_leaf_parts, format="csr")
+    return {
+        "models": models,
+        "encoders": encoders,
+        "train_leaf_matrix": train_leaf_matrix,
+        "eval_leaf_matrix": eval_leaf_matrix,
+        "leaf_feature_names": leaf_feature_names,
+    }
+
+
+class RidgeOnLGBMModel:
+    def __init__(self):
+        self.lgb_models = None
+        self.leaf_encoders = None
+        self.scaler = None
+        self.ridge = None
+        self.selected_indices = None
+        self.selected_feature_names = None
+        self.selected_raw_feature_names = None
+        self.selected_leaf_feature_names = None
+        self.selected_raw_indices = None
+        self.selected_leaf_indices = None
+        self.raw_feature_names = None
+        self.leaf_feature_names = None
+        self.combined_feature_names = None
+        self.oof_probs = None
+        self.uncertainty_features = None
+        self.confidence_norm = None
+        self.pruning_history = None
+
+    def _build_matrix(self, X):
+        x_np = np.asarray(X, dtype=np.float32)
+        leaf_parts = []
+        for lgbm, enc in zip(self.lgb_models, self.leaf_encoders):
+            leaf = lgbm.predict(x_np, pred_leaf=True)
+            leaf_parts.append(enc.transform(leaf))
+        leaf_oh = sparse.hstack(leaf_parts, format="csr")
+        return sparse.hstack([sparse.csr_matrix(x_np), leaf_oh], format="csr")
+
+    def predict_proba(self, X):
+        xc = self._build_matrix(X)
+        raw_part = xc[:, self.selected_raw_indices]
+        leaf_part = xc[:, self.selected_leaf_indices]
+        raw_scaled = (
+            self.scaler.transform(raw_part) if raw_part.shape[1] > 0 else raw_part
+        )
+        xs = sparse.hstack([raw_scaled, leaf_part], format="csr")
+        score = self.ridge.decision_function(xs)
+        p = 1.0 / (1.0 + np.exp(-score))
+        return np.column_stack([1.0 - p, p])
+
+    def predict(self, X):
+        return self.predict_proba(X)[:, 1]
+
+    def predict_uncertainty_features(self, X):
+        p = self.predict(X)
+        conf_raw = np.abs(p - 0.5) * 2.0
+        lo = (
+            float(self.confidence_norm["p5"])
+            if self.confidence_norm
+            else float(np.percentile(conf_raw, 5))
+        )
+        hi = (
+            float(self.confidence_norm["p95"])
+            if self.confidence_norm
+            else float(np.percentile(conf_raw, 95))
+        )
+        if hi <= lo:
+            conf = np.ones(len(conf_raw), dtype=np.float32)
+        else:
+            conf = 0.7 + 0.6 * np.clip((conf_raw - lo) / (hi - lo), 0.0, 1.0)
+        return {
+            "ridge_conf_clf_raw": conf_raw.astype(np.float32),
+            "ridge_conf_clf": conf.astype(np.float32),
+            "prefix_std": np.full(len(conf), np.std(p), dtype=np.float32),
+            "leaf_support_q25": np.full(len(conf), np.nan, dtype=np.float32),
+            "leaf_target_iqr_mean": np.full(len(conf), np.nan, dtype=np.float32),
+        }
+
+
+def train_ridge_on_lgbm_candidate(X, y, sample_weight=None, random_state=42):
+    y_bin = np.asarray(y >= 0.5, dtype=np.int8)
+    x_df = X if hasattr(X, "columns") else pd.DataFrame(X)
+    x_np = x_df.to_numpy(dtype=np.float32)
+    n = len(y_bin)
+    if lgb is None or n < 200:
+        return None
+
+    w_base = (
+        np.ones(n, dtype=np.float32)
+        if sample_weight is None
+        else np.asarray(sample_weight, dtype=np.float32)
+    )
+
+    race_idx = _stratified_subsample_indices(
+        y_bin, max_n=min(50000, n), random_state=random_state + 101
+    )
+    x_race = x_np[race_idx]
+    y_race = y_bin[race_idx]
+    w_race = w_base[race_idx]
+
+    outer_cv = StratifiedKFold(n_splits=2, shuffle=True, random_state=random_state)
+    oof_race = np.zeros(len(y_race), dtype=np.float32)
+    raw_lgbm2p_oof_race = np.zeros(len(y_race), dtype=np.float32)
+    ridge_fold_metrics: list[dict[str, float]] = []
+    raw_fold_metrics: list[dict[str, float]] = []
+
+    model = RidgeOnLGBMModel()
+    for tr_idx, va_idx in outer_cv.split(x_race, y_race):
+        x_tr, y_tr = x_race[tr_idx], y_race[tr_idx]
+        x_va, y_va = x_race[va_idx], y_race[va_idx]
+        bundle = _fit_lgbm_leaf_bundle(
+            x_tr, y_tr, x_va, y_va, random_state=random_state
+        )
+        raw_lgbm2p_oof_race[va_idx] = (
+            bundle["models"][0].predict_proba(x_va)[:, 1].astype(np.float32)
+        )
+        raw_fold_metrics.append(_metric_pack(y_va, raw_lgbm2p_oof_race[va_idx]))
+        x_tr_c = sparse.hstack(
+            [sparse.csr_matrix(x_tr), bundle["train_leaf_matrix"]], format="csr"
+        )
+        x_va_c = sparse.hstack(
+            [sparse.csr_matrix(x_va), bundle["eval_leaf_matrix"]], format="csr"
+        )
+
+        prune = _stage_a_prune(
+            x_tr_c,
+            y_tr,
+            random_state=random_state,
+            n_raw_total=x_tr.shape[1],
+            prior_round_pred=None,
+            initial_features=None,
+            max_rounds=7,
+        )
+        selected = np.asarray(prune["selected_indices"], dtype=np.int32)
+        last_en_oof = np.asarray(prune["last_round_en_oof"], dtype=np.float32)
+
+        n_raw_fold = x_tr.shape[1]
+        sel_raw = selected[selected < n_raw_fold]
+        sel_leaf = selected[selected >= n_raw_fold]
+        scaler = RobustScaler(with_centering=False)
+        xtr_raw = x_tr_c[:, sel_raw]
+        xva_raw = x_va_c[:, sel_raw]
+        xtr_raw_s = scaler.fit_transform(xtr_raw) if xtr_raw.shape[1] > 0 else xtr_raw
+        xva_raw_s = scaler.transform(xva_raw) if xva_raw.shape[1] > 0 else xva_raw
+        xtr_s = sparse.hstack([xtr_raw_s, x_tr_c[:, sel_leaf]], format="csr")
+        xva_s = sparse.hstack([xva_raw_s, x_va_c[:, sel_leaf]], format="csr")
+        ridge = RidgeClassifier(alpha=1.0, random_state=random_state)
+        w_rank_focus = top30_boundary_weight(last_en_oof)
+        w_final = np.asarray(w_race[tr_idx], dtype=np.float32) * w_rank_focus
+        ridge.fit(xtr_s, y_tr, sample_weight=w_final)
+        pred = (1.0 / (1.0 + np.exp(-ridge.decision_function(xva_s)))).astype(
+            np.float32
+        )
+        oof_race[va_idx] = pred
+        ridge_fold_metrics.append(_metric_pack(y_va, pred))
+
+    raw_lgbm_metrics = _metric_pack(y_race, raw_lgbm2p_oof_race)
+    raw_lgbm_metrics.update(_aggregate_j(raw_fold_metrics))
+
+    bundle_full = _fit_lgbm_leaf_bundle(
+        x_np, y_bin, x_np, None, random_state=random_state
+    )
+    model.lgb_models = bundle_full["models"]
+    model.leaf_encoders = bundle_full["encoders"]
+    model.leaf_feature_names = bundle_full["leaf_feature_names"]
+    x_full_c = sparse.hstack(
+        [sparse.csr_matrix(x_np), bundle_full["train_leaf_matrix"]], format="csr"
+    )
+
+    prune_full = _stage_a_prune(
+        x_full_c,
+        y_bin,
+        random_state=random_state,
+        n_raw_total=x_np.shape[1],
+        prior_round_pred=bundle_full["models"][0]
+        .predict_proba(x_np)[:, 1]
+        .astype(np.float32),
+        initial_features=None,
+        max_rounds=7,
+    )
+    model.selected_indices = np.asarray(prune_full["selected_indices"], dtype=np.int32)
+    last_round_en_oof = np.asarray(prune_full["last_round_en_oof"], dtype=np.float32)
+    model.pruning_history = prune_full["pruning_history"]
+
+    model.scaler = RobustScaler(with_centering=False)
+    model.selected_raw_indices = model.selected_indices[
+        model.selected_indices < x_np.shape[1]
+    ]
+    model.selected_leaf_indices = model.selected_indices[
+        model.selected_indices >= x_np.shape[1]
+    ]
+    x_raw = x_full_c[:, model.selected_raw_indices]
+    x_raw_s = model.scaler.fit_transform(x_raw) if x_raw.shape[1] > 0 else x_raw
+    xs = sparse.hstack(
+        [x_raw_s, x_full_c[:, model.selected_leaf_indices]], format="csr"
+    )
+    model.ridge = RidgeClassifier(alpha=1.0, random_state=random_state)
+    w_final_full = w_base * top30_boundary_weight(last_round_en_oof)
+    model.ridge.fit(xs, y_bin, sample_weight=w_final_full)
+
+    p_train = (1.0 / (1.0 + np.exp(-model.ridge.decision_function(xs)))).astype(
+        np.float32
+    )
+    oof_full = np.full(n, np.nan, dtype=np.float32)
+    oof_full[race_idx] = oof_race
+    model.oof_probs = oof_full
+    model.raw_feature_names = list(x_df.columns)
+    n_raw = len(model.raw_feature_names)
+    model.combined_feature_names = model.raw_feature_names + model.leaf_feature_names
+    model.selected_feature_names = [
+        model.combined_feature_names[i] for i in model.selected_indices
+    ]
+    model.selected_raw_feature_names = [
+        model.combined_feature_names[i] for i in model.selected_indices if i < n_raw
+    ]
+    model.selected_leaf_feature_names = [
+        model.combined_feature_names[i] for i in model.selected_indices if i >= n_raw
+    ]
+
+    conf_raw = np.abs(p_train - 0.5) * 2.0
+    model.confidence_norm = {
+        "p5": float(np.percentile(conf_raw, 5)) if len(conf_raw) else 0.0,
+        "p95": float(np.percentile(conf_raw, 95)) if len(conf_raw) else 1.0,
+    }
+    model.uncertainty_features = model.predict_uncertainty_features(x_np)
+
+    agg_oof = _aggregate_j(ridge_fold_metrics)
+    metric_train = _metric_pack(y_bin, p_train)
+    agg_train = _aggregate_j([metric_train])
+    j_final_train = float(agg_train["J_final"])
+    j_final_oof = float(agg_oof["J_final"])
+    oof_train_gap = float(
+        np.clip((j_final_train - j_final_oof) / max(abs(j_final_train), 1e-8), 0.0, 1.0)
+    )
+    j_race = float(j_final_oof * (1.0 - oof_train_gap))
+
+    metrics = _metric_pack(y_race, oof_race)
+    metrics.update(agg_oof)
+    metrics["J_final_train"] = j_final_train
+    metrics["J_final_oof"] = j_final_oof
+    metrics["OOF_Train_Gap"] = oof_train_gap
+    metrics["J_race"] = j_race
+    metrics["feature_count"] = int(len(model.selected_indices))
+    metrics["n_raw_features_kept"] = int(len(model.selected_raw_feature_names))
+    metrics["n_leaf_features_kept"] = int(len(model.selected_leaf_feature_names))
+    metrics["n_total_features_kept"] = int(len(model.selected_indices))
+
+    for key in [
+        "J_final_train",
+        "J_final_oof",
+        "OOF_Train_Gap",
+        "J_race",
+        "lift30",
+        "auc_correct_30",
+        "stability30",
+        "auc",
+        "pr_auc",
+        "pr_random",
+        "brier",
+        "ece",
+        "top30_correctness_rate",
+        "overall_correctness_rate",
+        "feature_count",
+        "oof_std",
+    ]:
+        print(f"{key}: {metrics.get(key)}")
+
+    return {
+        "model": model,
+        "metrics": metrics,
+        "raw_lgbm_2p_metrics": raw_lgbm_metrics,
+        "raw_lgbm_metrics": raw_lgbm_metrics,
+        "oof_probs": oof_full,
+        "pruning_history": prune_full["pruning_history"],
+        "last_round_en_oof": last_round_en_oof,
+        "uncertainty_features": model.uncertainty_features,
+    }

--- a/extreme_price_movements/training.py
+++ b/extreme_price_movements/training.py
@@ -34,6 +34,11 @@ from .gamma_specialist import build_gamma_dataset, train_gamma_from_dataset
 from .gate_metrics import compute_stage_gate_metrics
 from .labeling import compute_trailing_atr_labels, compute_triple_barrier_labels
 from .meta_model import MetaClassifierModel, MetaModel
+from .weak_residual_meta_learner import (
+    WeakResidualMetaClassifier,
+    WeakResidualMetaRegressor,
+    save_weak_meta_outputs,
+)
 from .meta_training.utility_smooth import (
     smooth_utility_from_log_heads,
     smooth_utility_from_log_heads_standardized,
@@ -13392,42 +13397,12 @@ def train_meta_models_from_artifacts(
 
         # Fit bucket-level regressor only when explicitly enabled (default disabled).
         if include_meta_reg:
-            meta_reg = MetaModel(reports_dir=reports_dir)
+            meta_reg = WeakResidualMetaRegressor(
+                strategy_name=_h_label, reports_dir=reports_dir
+            )
             meta_reg.strategy_name = _h_label
             meta_reg.hpo_n_trials = _meta_hpo_trials
             meta_reg.hpo_max_rows = _meta_hpo_max_rows
-            meta_reg.candidate_mode = "xgb_parallel_forest"
-            meta_reg.collect_uncertainty_metrics = False
-            meta_reg.disable_hpo = bool(
-                cfg.get("meta_parallel_forest_disable_hpo", False)
-            )
-            meta_reg.hpo_out_dir = _meta_hpo_out_dir
-            meta_reg.xgb_parallel_forest_params = {
-                "objective": "reg:pseudohubererror",
-                "n_estimators": int(cfg.get("meta_parallel_forest_rounds", 100)),
-                "num_parallel_tree": int(
-                    cfg.get("meta_parallel_forest_num_parallel_tree", 20)
-                ),
-                "max_depth": int(cfg.get("meta_parallel_forest_max_depth", 5)),
-                "learning_rate": float(
-                    cfg.get("meta_parallel_forest_learning_rate", 0.05)
-                ),
-                "subsample": 0.75,
-                "colsample_bytree": 0.75,
-                "reg_alpha": float(cfg.get("meta_parallel_forest_reg_alpha", 2.0)),
-                "reg_lambda": float(cfg.get("meta_parallel_forest_reg_lambda", 15.0)),
-                "min_child_weight": float(
-                    cfg.get("meta_parallel_forest_min_child_weight", 40.0)
-                ),
-                "gamma": float(cfg.get("meta_parallel_forest_gamma", 1.5)),
-                "tree_method": "hist",
-                "random_state": 42,
-                "n_jobs": 2,
-                "verbosity": 0,
-                "early_stopping_rounds": int(
-                    cfg.get("meta_parallel_forest_early_stopping_rounds", 20)
-                ),
-            }
             _meta_sel_cfg = dict(cfg.get("meta_selector_cfg", {}) or {})
             _meta_fs_dir = os.path.join(
                 str(cfg.get("data_root", "data")),
@@ -13900,18 +13875,12 @@ def train_meta_models_from_artifacts(
                 ),
             }
             _meta_clf_fee = float(cfg.get("label_round_trip_fee_pct", 0.3)) / 100.0
-            meta_clf = MetaClassifierModel(reports_dir=reports_dir)
+            meta_clf = WeakResidualMetaClassifier(
+                strategy_name=k, reports_dir=reports_dir
+            )
             meta_clf.strategy_name = k
             meta_clf.hpo_n_trials = _meta_hpo_trials
             meta_clf.hpo_max_rows = _meta_hpo_max_rows
-            meta_clf.candidate_mode = "xgb_parallel_forest"
-            meta_clf.collect_uncertainty_metrics = False
-            meta_clf.disable_hpo = bool(
-                cfg.get("meta_parallel_forest_disable_hpo", False)
-            )
-            meta_clf.hpo_out_dir = _meta_hpo_out_dir
-            meta_clf.xgb_parallel_forest_params = dict(_meta_clf_params)
-            meta_clf.FEE_PER_ROUND_TRIP = _meta_clf_fee
             _sel_cfg = MetaMoveSelectionConfig(
                 min_roc_auc=float(cfg.get("meta_move_min_roc_auc", 0.56)),
                 min_pr_auc=float(cfg.get("meta_move_min_pr_auc", 0.0)),
@@ -13952,6 +13921,20 @@ def train_meta_models_from_artifacts(
                     max_class_weight=float(cfg.get("meta_clf_max_class_weight", 10.0)),
                     use_calibration=bool(cfg.get("meta_clf_use_calibration", True)),
                     move_horizon=int(_mid_h),
+                    base_oof_pred=(
+                        np.asarray(
+                            X_meta_models[_base_prob_col].values, dtype=np.float32
+                        )
+                        if _base_prob_col is not None
+                        and _base_prob_col in X_meta_models.columns
+                        else np.asarray(y_target_clf, dtype=np.float32)
+                    ),
+                    y_true_clf=(
+                        np.asarray(df["__y_bin__"].values, dtype=np.float32)
+                        if "__y_bin__" in df.columns
+                        else np.asarray(_y_move, dtype=np.float32)
+                    ),
+                    base_threshold=float(cfg.get("base_clf_threshold", 0.5)),
                 )
                 meta_models[f"{_k_prefix}clf"] = meta_clf
                 _bucket_y_ret[f"{_k_prefix}clf"] = _y_move_soft.copy()
@@ -13987,6 +13970,47 @@ def train_meta_models_from_artifacts(
                     f"Meta {_k_prefix}clf: fitted ({_time.monotonic()-_t0_meta:.1f}s)."
                 )
                 _meta_clf_fitted = True
+                try:
+                    _base_clf_col = next(
+                        (
+                            c
+                            for c in X_meta_models.columns
+                            if c.startswith("pred_") and "reg" not in c
+                        ),
+                        None,
+                    )
+                    _base_reg_col = next(
+                        (c for c in X_meta_models.columns if c.startswith("pred_reg_")),
+                        None,
+                    )
+                    if (
+                        _base_clf_col is not None
+                        and _base_reg_col is not None
+                        and include_meta_reg
+                    ):
+                        _weak_out_dir = os.path.join(
+                            str(cfg.get("data_root", "data")),
+                            "artifacts",
+                            str(cfg.get("run_id", "default")),
+                            "models",
+                            "weak_meta",
+                            str(k),
+                        )
+                        save_weak_meta_outputs(
+                            out_dir=_weak_out_dir,
+                            base_clf_pred=np.asarray(
+                                X_meta_models[_base_clf_col].values, dtype=np.float32
+                            ),
+                            base_reg_pred=np.asarray(
+                                X_meta_models[_base_reg_col].values, dtype=np.float32
+                            ),
+                            clf_model=meta_clf,
+                            reg_model=meta_reg,
+                        )
+                except Exception as _weak_save_exc:
+                    tprint(
+                        f"Meta {k}: weak-residual output save skipped ({_weak_save_exc})"
+                    )
             except RuntimeError as _e_meta_clf:
                 tprint(
                     f"Meta {k}_clf: skipped "
@@ -13997,20 +14021,12 @@ def train_meta_models_from_artifacts(
                         f"Meta {k}_clf: retrying with hard-label fallback "
                         f"({_time.monotonic()-_t0_meta:.1f}s)."
                     )
-                    _meta_clf_fallback = MetaClassifierModel(reports_dir=reports_dir)
+                    _meta_clf_fallback = WeakResidualMetaClassifier(
+                        strategy_name=k, reports_dir=reports_dir
+                    )
                     _meta_clf_fallback.strategy_name = k
                     _meta_clf_fallback.hpo_n_trials = _meta_hpo_trials
                     _meta_clf_fallback.hpo_max_rows = _meta_hpo_max_rows
-                    _meta_clf_fallback.candidate_mode = "xgb_parallel_forest"
-                    _meta_clf_fallback.collect_uncertainty_metrics = False
-                    _meta_clf_fallback.disable_hpo = bool(
-                        cfg.get("meta_parallel_forest_disable_hpo", False)
-                    )
-                    _meta_clf_fallback.hpo_out_dir = _meta_hpo_out_dir
-                    _meta_clf_fallback.xgb_parallel_forest_params = dict(
-                        _meta_clf_params
-                    )
-                    _meta_clf_fallback.FEE_PER_ROUND_TRIP = _meta_clf_fee
                     _sel_cfg_fallback = MetaMoveSelectionConfig(
                         min_roc_auc=0.0,
                         min_pr_auc=0.0,
@@ -14042,6 +14058,20 @@ def train_meta_models_from_artifacts(
                         ),
                         use_calibration=bool(cfg.get("meta_clf_use_calibration", True)),
                         move_horizon=int(_mid_h),
+                        base_oof_pred=(
+                            np.asarray(
+                                X_meta_models[_base_prob_col].values, dtype=np.float32
+                            )
+                            if _base_prob_col is not None
+                            and _base_prob_col in X_meta_models.columns
+                            else np.asarray(y_target_clf, dtype=np.float32)
+                        ),
+                        y_true_clf=(
+                            np.asarray(df["__y_bin__"].values, dtype=np.float32)
+                            if "__y_bin__" in df.columns
+                            else np.asarray(_y_move, dtype=np.float32)
+                        ),
+                        base_threshold=float(cfg.get("base_clf_threshold", 0.5)),
                     )
                     meta_clf = _meta_clf_fallback
                     meta_models[f"{k}_clf"] = meta_clf
@@ -14757,6 +14787,42 @@ def train_meta_models_from_artifacts(
     def _trim_1d(values, n: int):
         return np.asarray(values).reshape(-1)[: int(n)]
 
+    def _append_weak_meta_oof_fields(oof_df: pd.DataFrame, meta_obj, n_rows: int):
+        """Append weak-residual OOF diagnostics into canonical meta_oof exports.
+
+        This keeps weak-meta outputs in artifacts/<run_id>/meta_oof so downstream
+        consumers (e.g., simple_position_sizer) can access them without reading
+        the sidecar weak_meta directory.
+        """
+        try:
+            _diag = getattr(meta_obj, "_diag", None)
+            if not isinstance(_diag, dict):
+                return oof_df
+
+            def _put(col_name: str, diag_key: str):
+                _v = _diag.get(diag_key)
+                if _v is None:
+                    return
+                _arr = np.asarray(_v).reshape(-1)
+                if len(_arr) >= int(n_rows):
+                    oof_df[col_name] = _trim_1d(_arr, n_rows)
+
+            # Classifier weak-meta fields
+            _put("meta_clf_ridge_pred", "ridge_prob_correct")
+            _put("meta_clf_lgbm_pred", "meta_clf_lgbm_adj")
+            _put("meta_clf_uncertainty", "meta_clf_uncertainty")
+            _put("meta_clf_final_raw", "meta_clf_final_raw")
+            _put("meta_clf_final", "final")
+
+            # Regressor weak-meta fields
+            _put("meta_reg_ridge_pred", "ridge_pred")
+            _put("meta_reg_lgbm_pred", "lgbm_pred")
+            _put("meta_reg_uncertainty", "meta_reg_uncertainty")
+            _put("meta_reg_final", "final")
+        except Exception:
+            return oof_df
+        return oof_df
+
     def compute_meta_expected_value(p_tp, p_sl, ratio):
         return ratio * p_tp - p_sl
 
@@ -15241,6 +15307,21 @@ def train_meta_models_from_artifacts(
                         oof_df[_cn] = _fill_nonfinite_oof_vector(
                             _aux[_cn], global_neutral=0.0
                         ).astype(np.float32, copy=False)
+
+            # Wire weak-residual OOF diagnostics into canonical meta_oof exports.
+            oof_df = _append_weak_meta_oof_fields(oof_df, meta, _n_meta)
+
+            # Universal per-head prediction diagnostics (constant columns so they
+            # travel with every exported head for downstream debugging).
+            if "oof_pred" in oof_df.columns:
+                _pred_arr = np.asarray(oof_df["oof_pred"].values, dtype=np.float64)
+                _pred_fin = _pred_arr[np.isfinite(_pred_arr)]
+                _mean_pred = (
+                    float(np.mean(_pred_fin)) if _pred_fin.size else float("nan")
+                )
+                _std_pred = float(np.std(_pred_fin)) if _pred_fin.size else float("nan")
+                oof_df["diag_mean_pred"] = _mean_pred
+                oof_df["diag_std_pred"] = _std_pred
 
             if key.endswith("_reg") and "oof_pred_oriented" not in oof_df.columns:
                 _score_sign = int(getattr(meta, "score_sign", 1))

--- a/extreme_price_movements/weak_residual_meta_learner.py
+++ b/extreme_price_movements/weak_residual_meta_learner.py
@@ -1,0 +1,972 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+import numpy as np
+import pandas as pd
+from scipy.stats import spearmanr
+from sklearn.isotonic import IsotonicRegression
+from sklearn.linear_model import ElasticNet, Ridge, RidgeClassifier
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import KFold, StratifiedKFold
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import RobustScaler
+
+try:
+    import lightgbm as lgb
+except Exception:  # pragma: no cover
+    lgb = None
+
+
+def _ranknorm(x: np.ndarray) -> np.ndarray:
+    v = np.asarray(x, dtype=np.float64)
+    if len(v) == 0:
+        return v.astype(np.float32)
+    order = np.argsort(v, kind="mergesort")
+    out = np.zeros(len(v), dtype=np.float64)
+    out[order] = np.linspace(0.0, 1.0, len(v), endpoint=True)
+    return out.astype(np.float32)
+
+
+def _safe_spearman(a: np.ndarray, b: np.ndarray) -> float:
+    m = np.isfinite(a) & np.isfinite(b)
+    if np.sum(m) < 8:
+        return 0.0
+    r = spearmanr(a[m], b[m]).correlation
+    return float(0.0 if not np.isfinite(r) else r)
+
+
+def _ece(y_true: np.ndarray, prob: np.ndarray, bins: int = 10) -> float:
+    y = np.asarray(y_true, dtype=np.float64)
+    p = np.clip(np.asarray(prob, dtype=np.float64), 1e-6, 1 - 1e-6)
+    m = np.isfinite(y) & np.isfinite(p)
+    if np.sum(m) < 10:
+        return 0.0
+    y = y[m]
+    p = p[m]
+    q = np.quantile(p, np.linspace(0.0, 1.0, bins + 1))
+    q[0] -= 1e-12
+    q[-1] += 1e-12
+    ece = 0.0
+    for i in range(bins):
+        mm = (p >= q[i]) & (p < q[i + 1] if i < bins - 1 else p <= q[i + 1])
+        if not np.any(mm):
+            continue
+        ece += abs(float(np.mean(y[mm])) - float(np.mean(p[mm]))) * (
+            np.sum(mm) / len(p)
+        )
+    return float(ece)
+
+
+def _norm_07_13(v: np.ndarray) -> np.ndarray:
+    x = np.asarray(v, dtype=np.float64)
+    lo = np.nanpercentile(x, 5)
+    hi = np.nanpercentile(x, 95)
+    if (not np.isfinite(lo)) or (not np.isfinite(hi)) or hi <= lo:
+        return np.ones(len(x), dtype=np.float32)
+    z = np.clip((x - lo) / (hi - lo), 0.0, 1.0)
+    return (0.7 + 0.6 * z).astype(np.float32)
+
+
+def _topk_mask(score: np.ndarray, frac: float = 0.30) -> np.ndarray:
+    n = len(score)
+    k = max(1, int(np.ceil(frac * n)))
+    idx = np.argsort(np.asarray(score, dtype=np.float64))[-k:]
+    m = np.zeros(n, dtype=bool)
+    m[idx] = True
+    return m
+
+
+def _stratified_subsample_idx(
+    strata: np.ndarray, max_n: int, seed: int = 42
+) -> np.ndarray:
+    n = len(strata)
+    if n <= max_n:
+        return np.arange(n, dtype=np.int32)
+    rng = np.random.default_rng(seed)
+    out = []
+    for s in np.unique(strata):
+        ids = np.where(strata == s)[0]
+        if len(ids) == 0:
+            continue
+        take = max(1, int(round(max_n * (len(ids) / n))))
+        take = min(take, len(ids))
+        out.append(rng.choice(ids, size=take, replace=False))
+    if not out:
+        return np.arange(max_n, dtype=np.int32)
+    idx = np.sort(np.concatenate(out).astype(np.int32))
+    if len(idx) > max_n:
+        idx = np.sort(rng.choice(idx, size=max_n, replace=False).astype(np.int32))
+    return idx
+
+
+def _metric_pack(y: np.ndarray, pred: np.ndarray, classifier: bool) -> Dict[str, float]:
+    # Internal proxy objective for feature filtering only (not canonical business metrics).
+    m30 = _topk_mask(pred, 0.30)
+    if classifier:
+        yb = np.asarray(y > 0.5, dtype=np.float64)
+        br = float(np.mean(yb))
+        p30 = float(np.mean(yb[m30])) if np.any(m30) else 0.0
+        lift = p30 / max(br, 1e-6)
+        ic30 = _safe_spearman(pred[m30], yb[m30]) if np.any(m30) else 0.0
+        # split top30 into 5 slices, use negative std as stability proxy
+        s_top = np.asarray(pred[m30], dtype=np.float64)
+        y_top = yb[m30]
+        if len(s_top) >= 10:
+            q = np.quantile(s_top, np.linspace(0.0, 1.0, 6))
+            vals = []
+            for i in range(5):
+                mm = (s_top >= q[i]) & (
+                    s_top < q[i + 1] if i < 4 else s_top <= q[i + 1]
+                )
+                if np.any(mm):
+                    vals.append(float(np.mean(y_top[mm])))
+            stab = float(1.0 / (1.0 + np.std(vals))) if vals else 0.0
+        else:
+            stab = 0.0
+        brier = float(np.mean((np.clip(pred, 1e-4, 1 - 1e-4) - yb) ** 2))
+        ece = _ece(yb, np.clip(pred, 1e-4, 1 - 1e-4), bins=10)
+    else:
+        yt = np.asarray(y, dtype=np.float64)
+        # Custom regression lift proxy: can behave differently on centered/heavy-tailed targets.
+        lift = (
+            float(np.mean(yt[m30]) / (np.mean(np.abs(yt)) + 1e-6))
+            if np.any(m30)
+            else 0.0
+        )
+        ic30 = _safe_spearman(pred[m30], yt[m30]) if np.any(m30) else 0.0
+        if np.any(m30):
+            s_top = np.asarray(pred[m30], dtype=np.float64)
+            y_top = yt[m30]
+            q = np.quantile(s_top, np.linspace(0.0, 1.0, 6))
+            vals = []
+            for i in range(5):
+                mm = (s_top >= q[i]) & (
+                    s_top < q[i + 1] if i < 4 else s_top <= q[i + 1]
+                )
+                if np.any(mm):
+                    vals.append(float(np.mean(y_top[mm])))
+            stab = float(1.0 / (1.0 + np.std(vals))) if vals else 0.0
+        else:
+            stab = 0.0
+        brier = float(np.mean((pred - yt) ** 2))
+        ece = 0.0
+    return {
+        "lift30": lift,
+        "ic30": ic30,
+        "stability30": stab,
+        "brier": brier,
+        "ece": ece,
+    }
+
+
+def _z(x: np.ndarray) -> np.ndarray:
+    x = np.asarray(x, dtype=np.float64)
+    s = np.nanstd(x)
+    if (not np.isfinite(s)) or s < 1e-9:
+        return np.zeros(len(x), dtype=np.float64)
+    return (x - np.nanmean(x)) / s
+
+
+def _preridge_elasticnet_select(
+    X: pd.DataFrame,
+    y: np.ndarray,
+    *,
+    classifier: bool,
+    max_keep: int = 120,
+) -> list[str]:
+    cols = list(X.columns)
+    if len(cols) <= max_keep:
+        return cols
+    Xv = X.to_numpy(dtype=np.float32)
+    yv = np.asarray(y, dtype=np.float32)
+    grid = [(a, l) for a in (0.01, 0.05, 0.1, 0.5, 1.0) for l in (0.2, 0.5, 0.8)]
+    cv = (
+        StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
+        if classifier
+        else KFold(n_splits=5, shuffle=True, random_state=42)
+    )
+    y_split = yv.astype(np.int8) if classifier else yv
+    rec = []
+    coef_maps = []
+    for alpha, l1 in grid:
+        oof = np.zeros(len(yv), dtype=np.float32)
+        fold_stats = []
+        coef = np.zeros(Xv.shape[1], dtype=np.float64)
+        for tr, va in cv.split(Xv, y_split):
+            sc = RobustScaler()
+            Xtr = sc.fit_transform(Xv[tr])
+            Xva = sc.transform(Xv[va])
+            if classifier:
+                # Deliberate classifier-aligned sparse linear selector (L1 logistic),
+                # used only as a feature ranking/filter stage before RidgeClassifier.
+                c_val = 1.0 / max(alpha, 1e-6)
+                mdl = LogisticRegression(
+                    penalty="l1",
+                    solver="liblinear",
+                    C=c_val,
+                    max_iter=2000,
+                    random_state=42,
+                )
+                mdl.fit(Xtr, y_split[tr])
+                oof[va] = mdl.predict_proba(Xva)[:, 1].astype(np.float32)
+                coef += np.abs(np.ravel(mdl.coef_))
+            else:
+                mdl = ElasticNet(
+                    alpha=alpha, l1_ratio=l1, max_iter=4000, random_state=42
+                )
+                mdl.fit(Xtr, yv[tr])
+                oof[va] = mdl.predict(Xva).astype(np.float32)
+                coef += np.abs(mdl.coef_)
+            fold_stats.append(_metric_pack(yv[va], oof[va], classifier=classifier))
+        coef_maps.append(coef / max(1, cv.get_n_splits()))
+        metrics = {
+            k: float(np.mean([r[k] for r in fold_stats])) for k in fold_stats[0].keys()
+        }
+        rec.append(metrics)
+    lift_z = _z(np.array([r["lift30"] for r in rec]))
+    ic_z = _z(np.array([r["ic30"] for r in rec]))
+    stab_z = _z(np.array([r["stability30"] for r in rec]))
+    brier_z = _z(np.array([r["brier"] for r in rec]))
+    ece_z = _z(np.array([r["ece"] for r in rec]))
+    obj = 0.35 * lift_z + 0.35 * ic_z + 0.20 * stab_z - 0.05 * brier_z - 0.05 * ece_z
+    best = int(np.nanargmax(obj))
+    coef = coef_maps[best]
+    order = np.argsort(coef)[::-1][:max_keep]
+    return [cols[i] for i in order]
+
+
+def _cluster_redundant_features(
+    X: pd.DataFrame, y: np.ndarray, thr: float = 0.97
+) -> list[str]:
+    cols = list(X.columns)
+    if len(cols) <= 2:
+        return cols
+    xs = X.to_numpy(dtype=np.float32)
+    sub_n = min(len(xs), 5000)
+    rng = np.random.default_rng(42)
+    idx = (
+        rng.choice(len(xs), size=sub_n, replace=False)
+        if len(xs) > sub_n
+        else np.arange(len(xs))
+    )
+    sub = pd.DataFrame(xs[idx], columns=cols).rank(pct=True)
+    corr = np.abs(np.corrcoef(sub.to_numpy(dtype=np.float64), rowvar=False))
+    yv = np.asarray(y, dtype=np.float64)
+    rel = np.array(
+        [abs(_safe_spearman(X[c].values, yv)) for c in cols], dtype=np.float64
+    )
+    keep = []
+    dropped = np.zeros(len(cols), dtype=bool)
+    for i in np.argsort(rel)[::-1]:
+        if dropped[i]:
+            continue
+        keep.append(cols[i])
+        drop_i = corr[i] > thr
+        dropped |= drop_i
+        dropped[i] = False
+    return keep
+
+
+def _univariate_screen(
+    X: pd.DataFrame,
+    y: np.ndarray,
+    ridge_pred: np.ndarray,
+    signed_residual: np.ndarray,
+    *,
+    top_k: int = 150,
+) -> list[str]:
+    cols = list(X.columns)
+    if len(cols) <= top_k:
+        return cols
+    rp = _ranknorm(ridge_pred)
+    buckets = np.clip((rp * 5).astype(np.int32), 0, 4)
+    idx = _stratified_subsample_idx(buckets, max_n=25000, seed=42)
+    Xs = X.iloc[idx]
+    y_s = np.asarray(y, dtype=np.float64)[idx]
+    r_s = np.asarray(ridge_pred, dtype=np.float64)[idx]
+    sr_s = np.asarray(signed_residual, dtype=np.float64)[idx]
+    b_s = buckets[idx]
+    scores = []
+    for c in cols:
+        z = np.asarray(Xs[c].values, dtype=np.float64)
+        c1 = []
+        c2 = []
+        for b in range(5):
+            m = b_s == b
+            if np.sum(m) < 8:
+                continue
+            c1.append(_safe_spearman(z[m], sr_s[m]))
+            c2.append(_safe_spearman((z[m] * r_s[m]), y_s[m]))
+        if not c1:
+            scores.append(-1e9)
+            continue
+        c1 = np.asarray(c1)
+        c2 = np.asarray(c2)
+        sc = abs(np.mean(c1)) - 0.5 * np.std(c1) + abs(np.mean(c2)) - 0.5 * np.std(c2)
+        scores.append(float(sc))
+    ord_idx = np.argsort(np.asarray(scores))[::-1][:top_k]
+    return [cols[i] for i in ord_idx]
+
+
+def _iterative_fold_presence_prune(
+    X: pd.DataFrame,
+    target: np.ndarray,
+    *,
+    classifier: bool,
+    min_features: int = 40,
+) -> list[str]:
+    cols = list(X.columns)
+    if len(cols) <= min_features or lgb is None:
+        return cols
+    presence = {c: 0 for c in cols}
+    gain = {c: 0.0 for c in cols}
+    y_split = target.astype(np.int32) if classifier else target
+    if classifier:
+        _classes, _counts = np.unique(y_split, return_counts=True)
+        if len(_classes) >= 2 and int(np.min(_counts)) >= 5:
+            cv = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
+        else:
+            cv = KFold(n_splits=5, shuffle=True, random_state=42)
+    else:
+        cv = KFold(n_splits=5, shuffle=True, random_state=42)
+    Xv = X.to_numpy(dtype=np.float32)
+    yv = np.asarray(target)
+    for tr, va in cv.split(Xv, y_split):
+        if classifier:
+            model = lgb.LGBMClassifier(
+                objective="multiclass",
+                num_class=3,
+                n_estimators=500,
+                max_depth=2,
+                min_data_in_leaf=100,
+                learning_rate=0.05,
+                random_state=42,
+                n_jobs=2,
+            )
+        else:
+            model = lgb.LGBMRegressor(
+                objective="huber",
+                n_estimators=500,
+                max_depth=2,
+                min_data_in_leaf=100,
+                learning_rate=0.05,
+                random_state=42,
+                n_jobs=2,
+            )
+        model.fit(
+            Xv[tr],
+            yv[tr],
+            eval_set=[(Xv[va], yv[va])],
+            eval_metric="l2",
+            callbacks=[lgb.early_stopping(25, verbose=False)],
+        )
+        imp = model.booster_.feature_importance(importance_type="gain")
+        nz = imp > 0
+        for i, c in enumerate(cols):
+            if nz[i]:
+                presence[c] += 1
+                gain[c] += float(imp[i])
+    curr = set(cols)
+    for ratio in (0.3, 0.4, 0.5, 0.6, 0.7, 0.8):
+        need = max(1, int(np.ceil(5 * ratio)))
+        curr = {c for c in curr if presence.get(c, 0) >= need}
+        if len(curr) <= min_features:
+            break
+    if len(curr) < min_features:
+        rank = sorted(
+            cols, key=lambda c: (presence.get(c, 0), gain.get(c, 0.0)), reverse=True
+        )
+        curr = set(rank[:min_features])
+    return [c for c in cols if c in curr]
+
+
+class WeakResidualMetaRegressor:
+    def __init__(
+        self, strategy_name: Optional[str] = None, reports_dir: Optional[str] = None
+    ):
+        self.strategy_name = strategy_name
+        self.reports_dir = reports_dir
+        self.selected_features: list[str] = []
+        self.ridge_model: Optional[Pipeline] = None
+        self.lgbm_model: Optional[Any] = None
+        self.oof_probs: Optional[np.ndarray] = None
+        self.model: Optional[Any] = None
+        self._diag: Dict[str, np.ndarray] = {}
+        self._leaf_var_maps: list[dict[int, float]] = []
+        self._leaf_cnt_maps: list[dict[int, int]] = []
+        self._reg_unc_a: float = 1.0
+        self._reg_unc_C: float = 1.0
+        self._reg_unc_lo: float = 0.0
+        self._reg_unc_hi: float = 1.0
+
+    def _compute_reg_lgbm_uncertainty(
+        self, X_lgb_np: np.ndarray
+    ) -> dict[str, np.ndarray]:
+        n = len(X_lgb_np)
+        if (
+            len(self._leaf_var_maps) == 0 or len(self._leaf_cnt_maps) == 0
+        ) and isinstance(self._diag, dict):
+            _v = self._diag.get("leaf_var_maps")
+            _c = self._diag.get("leaf_cnt_maps")
+            if _v is not None and _c is not None:
+                try:
+                    self._leaf_var_maps = list(_v)
+                    self._leaf_cnt_maps = list(_c)
+                except Exception:
+                    self._leaf_var_maps = []
+                    self._leaf_cnt_maps = []
+        if (
+            self.lgbm_model is None
+            or not hasattr(self.lgbm_model, "booster_")
+            or len(self._leaf_var_maps) == 0
+            or len(self._leaf_cnt_maps) == 0
+        ):
+            ones = np.ones(n, dtype=np.float32)
+            return {
+                "leaf_var": np.zeros(n, dtype=np.float32),
+                "leaf_count": ones.copy(),
+                "support_factor": ones.copy(),
+                "uncertainty": ones.copy(),
+                "leaf_count_q25": ones.copy(),
+            }
+        leaf = self.lgbm_model.booster_.predict(X_lgb_np, pred_leaf=True)
+        leaf = np.asarray(leaf, dtype=np.int64)
+        if leaf.ndim == 1:
+            leaf = leaf.reshape(-1, 1)
+        n_trees = leaf.shape[1]
+        lv = np.zeros(len(leaf), dtype=np.float64)
+        lc = np.zeros(len(leaf), dtype=np.float64)
+        lc_trees = np.zeros((len(leaf), n_trees), dtype=np.float64)
+        for t in range(n_trees):
+            vmap = self._leaf_var_maps[t] if t < len(self._leaf_var_maps) else {}
+            cmap = self._leaf_cnt_maps[t] if t < len(self._leaf_cnt_maps) else {}
+            ids = leaf[:, t]
+            lv += np.array(
+                [float(vmap.get(int(i), 0.0)) for i in ids], dtype=np.float64
+            )
+            lc += np.array([float(cmap.get(int(i), 1)) for i in ids], dtype=np.float64)
+            lc_trees[:, t] = np.array(
+                [float(cmap.get(int(i), 1)) for i in ids], dtype=np.float64
+            )
+        mean_leaf_var = (lv / max(n_trees, 1)).astype(np.float32)
+        mean_leaf_count = (lc / max(n_trees, 1)).astype(np.float32)
+        support_factor = np.log1p(mean_leaf_count) / max(
+            np.log1p(float(self._reg_unc_C)), 1e-6
+        )
+        unc_raw = support_factor / (1.0 + float(self._reg_unc_a) * mean_leaf_var)
+        lo = float(self._reg_unc_lo)
+        hi = float(self._reg_unc_hi)
+        if np.isfinite(lo) and np.isfinite(hi) and hi > lo:
+            unc = 0.7 + 0.6 * np.clip((unc_raw - lo) / (hi - lo), 0.0, 1.0)
+        else:
+            unc = np.ones(len(unc_raw), dtype=np.float32)
+        return {
+            "leaf_var": mean_leaf_var.astype(np.float32),
+            "leaf_count": mean_leaf_count.astype(np.float32),
+            "support_factor": np.asarray(support_factor, dtype=np.float32),
+            "uncertainty": np.asarray(unc, dtype=np.float32),
+            "leaf_count_q25": np.nanpercentile(lc_trees, 25, axis=1).astype(np.float32),
+        }
+
+    def fit(
+        self, X, y, sample_weight=None, groups=None, y_per_horizon=None, y_binary=None
+    ):
+        X_df = pd.DataFrame(X).replace([np.inf, -np.inf], 0.0).fillna(0.0)
+        y_t = np.asarray(y, dtype=np.float32)
+
+        ridge_feats = _preridge_elasticnet_select(
+            X_df, y_t, classifier=False, max_keep=120
+        )
+        X_ridge = X_df[ridge_feats]
+        ridge = Pipeline(
+            [("scaler", RobustScaler()), ("ridge", Ridge(alpha=0.5, random_state=42))]
+        )
+        if sample_weight is None:
+            ridge.fit(X_ridge, y_t)
+        else:
+            ridge.fit(
+                X_ridge,
+                y_t,
+                ridge__sample_weight=np.asarray(sample_weight, dtype=np.float32),
+            )
+        ridge_pred = ridge.predict(X_ridge).astype(np.float32)
+
+        ridge_target = y_t
+        signed_residual = (ridge_target - ridge_pred).astype(np.float32)
+        lgb_feats = _cluster_redundant_features(
+            X_df[ridge_feats], signed_residual, thr=0.97
+        )
+        X_lgb0 = X_df[lgb_feats]
+        lgb_feats = _univariate_screen(
+            X_lgb0, ridge_target, ridge_pred, signed_residual, top_k=150
+        )
+        X_lgb1 = X_lgb0[lgb_feats]
+        lgb_feats = _iterative_fold_presence_prune(
+            X_lgb1, signed_residual, classifier=False, min_features=40
+        )
+        X_lgb = X_lgb1[lgb_feats]
+
+        if lgb is not None and X_lgb.shape[1] > 0:
+            lgbm = lgb.LGBMRegressor(
+                objective="huber",
+                n_estimators=500,
+                max_depth=2,
+                min_data_in_leaf=100,
+                learning_rate=0.05,
+                random_state=42,
+                n_jobs=2,
+            )
+            X_lgb_np = X_lgb.to_numpy(dtype=np.float32)
+            lgbm.fit(X_lgb_np, signed_residual)
+            lgb_pred = lgbm.predict(X_lgb_np).astype(np.float32)
+            train_leaf = np.asarray(
+                lgbm.booster_.predict(X_lgb_np, pred_leaf=True), dtype=np.int64
+            )
+            if train_leaf.ndim == 1:
+                train_leaf = train_leaf.reshape(-1, 1)
+            self._leaf_var_maps = []
+            self._leaf_cnt_maps = []
+            # Note: these maps are fit on the same rows used to train this v1 model.
+            # Diagnostics on train rows are therefore optimistic by construction.
+            for t in range(train_leaf.shape[1]):
+                ids = train_leaf[:, t]
+                vmap: dict[int, float] = {}
+                cmap: dict[int, int] = {}
+                uniq = np.unique(ids)
+                for lid in uniq:
+                    m = ids == lid
+                    vals = signed_residual[m]
+                    vmap[int(lid)] = float(np.var(vals)) if len(vals) > 0 else 0.0
+                    cmap[int(lid)] = int(np.sum(m))
+                self._leaf_var_maps.append(vmap)
+                self._leaf_cnt_maps.append(cmap)
+            train_unc = self._compute_reg_lgbm_uncertainty(X_lgb_np)
+            leaf_var = train_unc["leaf_var"]
+            leaf_cnt = train_unc["leaf_count"]
+        else:
+            lgbm = None
+            lgb_pred = np.zeros(len(X_df), dtype=np.float32)
+            leaf_var = np.full(len(X_df), np.nanvar(signed_residual), dtype=np.float32)
+            leaf_cnt = np.ones(len(X_df), dtype=np.float32)
+            self._leaf_var_maps = []
+            self._leaf_cnt_maps = []
+
+        self._reg_unc_a = 1.0
+        self._reg_unc_C = float(np.percentile(leaf_cnt, 95))
+        support_factor = np.log1p(leaf_cnt) / max(np.log1p(self._reg_unc_C), 1e-6)
+        unc_raw = support_factor / (1.0 + self._reg_unc_a * leaf_var)
+        self._reg_unc_lo = float(np.percentile(unc_raw, 5))
+        self._reg_unc_hi = float(np.percentile(unc_raw, 95))
+        if self._reg_unc_hi > self._reg_unc_lo:
+            unc = 0.7 + 0.6 * np.clip(
+                (unc_raw - self._reg_unc_lo) / (self._reg_unc_hi - self._reg_unc_lo),
+                0.0,
+                1.0,
+            )
+        else:
+            unc = np.ones(len(unc_raw), dtype=np.float32)
+        final = ridge_pred + 0.3 * lgb_pred * unc
+
+        self.selected_features = list(dict.fromkeys(ridge_feats + lgb_feats))
+        self.ridge_model = ridge
+        self.lgbm_model = lgbm
+        self.model = ridge
+        self.oof_probs = final.astype(np.float32)
+        self._diag = {
+            "ridge_features": np.array(ridge_feats, dtype=object),
+            "lgbm_features": np.array(lgb_feats, dtype=object),
+            "ridge_pred": ridge_pred,
+            "lgbm_pred": lgb_pred,
+            "meta_reg_leaf_var": leaf_var,
+            "meta_reg_leaf_count": leaf_cnt,
+            "meta_reg_support_factor": support_factor.astype(np.float32),
+            "meta_reg_uncertainty": unc.astype(np.float32),
+            "final": final.astype(np.float32),
+            "unc_lo": np.float32(self._reg_unc_lo),
+            "unc_hi": np.float32(self._reg_unc_hi),
+            "unc_a": np.float32(self._reg_unc_a),
+            "leaf_count_cap_C": np.float32(self._reg_unc_C),
+            # Persist compact leaf maps in diagnostic payload for artifact tracing.
+            "leaf_var_maps": np.array(self._leaf_var_maps, dtype=object),
+            "leaf_cnt_maps": np.array(self._leaf_cnt_maps, dtype=object),
+        }
+        return self
+
+    def predict(self, X):
+        X_df = pd.DataFrame(X).replace([np.inf, -np.inf], 0.0).fillna(0.0)
+        rf = [c for c in self._diag.get("ridge_features", []) if c in X_df.columns]
+        lf = [c for c in self._diag.get("lgbm_features", []) if c in X_df.columns]
+        r = self.ridge_model.predict(X_df.reindex(columns=rf, fill_value=0.0)).astype(
+            np.float32
+        )
+        X_lgb_np = X_df.reindex(columns=lf, fill_value=0.0).to_numpy(dtype=np.float32)
+        l = (
+            self.lgbm_model.predict(X_lgb_np).astype(np.float32)
+            if self.lgbm_model is not None and len(lf) > 0
+            else np.zeros(len(X_df), dtype=np.float32)
+        )
+        u_dict = self._compute_reg_lgbm_uncertainty(X_lgb_np)
+        u = u_dict["uncertainty"]
+        return (r + 0.3 * l * u).astype(np.float32)
+
+    def predict_uncertainty_features(self, X):
+        n = len(X)
+        X_df = pd.DataFrame(X).replace([np.inf, -np.inf], 0.0).fillna(0.0)
+        lf = [c for c in self._diag.get("lgbm_features", []) if c in X_df.columns]
+        X_lgb_np = X_df.reindex(columns=lf, fill_value=0.0).to_numpy(dtype=np.float32)
+        uu = self._compute_reg_lgbm_uncertainty(X_lgb_np)
+        out = {}
+        out["leaf_var"] = (
+            uu["leaf_var"]
+            if len(uu["leaf_var"]) == n
+            else np.full(n, np.nan, dtype=np.float32)
+        )
+        out["leaf_count"] = (
+            uu["leaf_count"]
+            if len(uu["leaf_count"]) == n
+            else np.full(n, np.nan, dtype=np.float32)
+        )
+        out["support_factor"] = (
+            uu["support_factor"]
+            if len(uu["support_factor"]) == n
+            else np.full(n, np.nan, dtype=np.float32)
+        )
+        out["uncertainty"] = (
+            uu["uncertainty"]
+            if len(uu["uncertainty"]) == n
+            else np.full(n, np.nan, dtype=np.float32)
+        )
+        out["prefix_std"] = np.full(
+            n, np.nanstd(self._diag.get("final", np.zeros(n))), dtype=np.float32
+        )
+        out["leaf_support_q25"] = (
+            uu["leaf_count_q25"]
+            if len(uu.get("leaf_count_q25", [])) == n
+            else np.full(n, np.nan, dtype=np.float32)
+        )
+        out["leaf_target_iqr_mean"] = out["leaf_var"]
+        return out
+
+
+class WeakResidualMetaClassifier:
+    def __init__(
+        self, strategy_name: Optional[str] = None, reports_dir: Optional[str] = None
+    ):
+        self.strategy_name = strategy_name
+        self.reports_dir = reports_dir
+        self.selected_features: list[str] = []
+        self.ridge_model: Optional[Pipeline] = None
+        self.lgbm_model: Optional[Any] = None
+        self.calibrator: Optional[Any] = None
+        self.model: Optional[Any] = None
+        self.oof_probs: Optional[np.ndarray] = None
+        self._diag: Dict[str, np.ndarray] = {}
+
+    def fit(self, X, y, sample_weight=None, groups=None, **kwargs):
+        X_df = pd.DataFrame(X).replace([np.inf, -np.inf], 0.0).fillna(0.0)
+
+        base_oof_pred = kwargs.get("base_oof_pred")
+        y_true_clf = kwargs.get("y_true_clf")
+        base_threshold = float(kwargs.get("base_threshold", 0.5))
+        if base_oof_pred is None:
+            base_oof_pred = kwargs.get("y_move_override", y)
+        if y_true_clf is None:
+            y_true_clf = kwargs.get("y_class_override", y)
+
+        base_prob = np.asarray(base_oof_pred, dtype=np.float32)
+        y_true = (np.asarray(y_true_clf, dtype=np.float32) > 0.5).astype(np.int8)
+        base_pred_class = (base_prob >= base_threshold).astype(np.int8)
+        base_clf_correct = (base_pred_class == y_true).astype(np.int8)
+
+        ridge_feats = _preridge_elasticnet_select(
+            X_df, base_clf_correct.astype(np.float32), classifier=True, max_keep=120
+        )
+        X_ridge = X_df[ridge_feats]
+        X_ridge_np = X_ridge.to_numpy(dtype=np.float32)
+        sw = (
+            np.ones(len(X_ridge_np), dtype=np.float32)
+            if sample_weight is None
+            else np.asarray(sample_weight, dtype=np.float32)
+        )
+
+        cv = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
+        ridge_oof_prob = np.zeros(len(X_ridge_np), dtype=np.float32)
+        for tr, va in cv.split(X_ridge_np, base_clf_correct):
+            fold = Pipeline(
+                [
+                    ("scaler", RobustScaler()),
+                    ("ridge", RidgeClassifier(alpha=0.5, random_state=42)),
+                ]
+            )
+            fold.fit(
+                X_ridge_np[tr],
+                base_clf_correct[tr],
+                ridge__sample_weight=sw[tr],
+            )
+            score_va = fold.decision_function(X_ridge_np[va]).astype(np.float32)
+            ridge_oof_prob[va] = 1.0 / (1.0 + np.exp(-score_va))
+
+        ridge = Pipeline(
+            [
+                ("scaler", RobustScaler()),
+                ("ridge", RidgeClassifier(alpha=0.5, random_state=42)),
+            ]
+        )
+        ridge.fit(X_ridge_np, base_clf_correct, ridge__sample_weight=sw)
+
+        clf_residual = base_clf_correct.astype(np.float32) - ridge_oof_prob
+        y3 = np.ones(len(clf_residual), dtype=np.int32)
+        for tr, va in cv.split(X_ridge_np, base_clf_correct):
+            q1, q2 = np.quantile(clf_residual[tr], [1 / 3, 2 / 3])
+            y3[va] = 1
+            y3[va][clf_residual[va] < q1] = 0
+            y3[va][clf_residual[va] >= q2] = 2
+
+        lgb_feats = _cluster_redundant_features(
+            X_df[ridge_feats], clf_residual, thr=0.97
+        )
+        X_lgb0 = X_df[lgb_feats]
+        lgb_feats = _univariate_screen(
+            X_lgb0,
+            base_clf_correct.astype(np.float32),
+            ridge_oof_prob,
+            clf_residual,
+            top_k=150,
+        )
+        X_lgb1 = X_lgb0[lgb_feats]
+        lgb_feats = _iterative_fold_presence_prune(
+            X_lgb1, y3, classifier=True, min_features=40
+        )
+        X_lgb = X_lgb1[lgb_feats]
+
+        if lgb is not None and X_lgb.shape[1] > 0:
+            X_lgb_np = X_lgb.to_numpy(dtype=np.float32)
+            p3 = np.zeros((len(X_lgb_np), 3), dtype=np.float32)
+            cv_lgb = StratifiedKFold(n_splits=5, shuffle=True, random_state=44)
+            for tr, va in cv_lgb.split(X_lgb_np, y3):
+                clf_fold = lgb.LGBMClassifier(
+                    objective="multiclass",
+                    num_class=3,
+                    n_estimators=500,
+                    max_depth=2,
+                    min_data_in_leaf=100,
+                    learning_rate=0.05,
+                    random_state=42,
+                    n_jobs=2,
+                )
+                clf_fold.fit(X_lgb_np[tr], y3[tr])
+                p3[va] = clf_fold.predict_proba(X_lgb_np[va]).astype(np.float32)
+            clf = lgb.LGBMClassifier(
+                objective="multiclass",
+                num_class=3,
+                n_estimators=500,
+                max_depth=2,
+                min_data_in_leaf=100,
+                learning_rate=0.05,
+                random_state=42,
+                n_jobs=2,
+            )
+            clf.fit(X_lgb_np, y3)
+        else:
+            clf = None
+            p3 = np.full((len(X_lgb), 3), 1.0 / 3.0, dtype=np.float32)
+
+        eps = 1e-9
+        ent = -np.sum(p3 * np.log(np.clip(p3, eps, 1.0)), axis=1) / np.log(3.0)
+        extreme = p3[:, 0] + p3[:, 2]
+        top2 = np.partition(p3, -2, axis=1)[:, -2:]
+        margin = top2[:, 1] - top2[:, 0]
+        unc_raw = 0.5 * (1.0 - ent) + 0.25 * extreme + 0.25 * margin
+        unc = _norm_07_13(unc_raw)
+        lambda_clf = float(kwargs.get("lambda_clf", 0.3))
+        lgb_signed = p3[:, 2] - p3[:, 0]  # p_under - p_over
+        final_raw = np.clip(
+            ridge_oof_prob + lambda_clf * lgb_signed * unc, 1e-4, 1 - 1e-4
+        )
+
+        final_cal_oof = np.zeros(len(final_raw), dtype=np.float32)
+        cal_cv = StratifiedKFold(n_splits=5, shuffle=True, random_state=43)
+        for tr, va in cal_cv.split(final_raw.reshape(-1, 1), base_clf_correct):
+            cal_fold = IsotonicRegression(out_of_bounds="clip")
+            cal_fold.fit(final_raw[tr], base_clf_correct[tr])
+            final_cal_oof[va] = np.clip(cal_fold.predict(final_raw[va]), 1e-4, 1 - 1e-4)
+        final = np.clip(final_cal_oof, 1e-4, 1 - 1e-4)
+        # Deployment calibrator is full-fit on all training rows.
+        # _diag["final"] remains cross-fit calibrated OOF.
+        cal = IsotonicRegression(out_of_bounds="clip")
+        cal.fit(final_raw, base_clf_correct)
+
+        self.selected_features = list(dict.fromkeys(ridge_feats + lgb_feats))
+        self.ridge_model = ridge
+        self.lgbm_model = clf
+        self.calibrator = cal
+        self.model = ridge
+        self.oof_probs = final.astype(np.float32)
+        self._diag = {
+            "ridge_features": np.array(ridge_feats, dtype=object),
+            "lgbm_features": np.array(lgb_feats, dtype=object),
+            "base_clf_correct": base_clf_correct.astype(np.float32),
+            "ridge_prob_correct": ridge_oof_prob.astype(np.float32),
+            "meta_clf_lgbm_adj": lgb_signed.astype(np.float32),
+            "lgbm_pred": lgb_signed.astype(np.float32),  # backward compat
+            "meta_clf_entropy": ent.astype(np.float32),
+            "meta_clf_extreme_mass": extreme.astype(np.float32),
+            "meta_clf_margin": margin.astype(np.float32),
+            "meta_clf_uncertainty": unc.astype(np.float32),
+            "meta_clf_final_raw": final_raw.astype(np.float32),
+            "final": final.astype(np.float32),
+            "unc_lo": float(np.nanpercentile(unc_raw, 5)),
+            "unc_hi": float(np.nanpercentile(unc_raw, 95)),
+            "lambda_clf": lambda_clf,
+        }
+        return self
+
+    def predict_proba(self, X):
+        X_df = pd.DataFrame(X).replace([np.inf, -np.inf], 0.0).fillna(0.0)
+        rf = [c for c in self._diag.get("ridge_features", []) if c in X_df.columns]
+        lf = [c for c in self._diag.get("lgbm_features", []) if c in X_df.columns]
+        score = self.ridge_model.decision_function(
+            X_df.reindex(columns=rf, fill_value=0.0)
+        ).astype(np.float32)
+        p_r = 1.0 / (1.0 + np.exp(-score))
+        if self.lgbm_model is not None and len(lf) > 0:
+            p3 = self.lgbm_model.predict_proba(
+                X_df.reindex(columns=lf, fill_value=0.0)
+            ).astype(np.float32)
+            lgb_signed = p3[:, 2] - p3[:, 0]
+            eps = 1e-9
+            ent = -np.sum(p3 * np.log(np.clip(p3, eps, 1.0)), axis=1) / np.log(3.0)
+            extreme = p3[:, 0] + p3[:, 2]
+            top2 = np.partition(p3, -2, axis=1)[:, -2:]
+            margin = top2[:, 1] - top2[:, 0]
+            unc_raw = 0.5 * (1.0 - ent) + 0.25 * extreme + 0.25 * margin
+            lo = float(self._diag.get("unc_lo", np.nanpercentile(unc_raw, 5)))
+            hi = float(self._diag.get("unc_hi", np.nanpercentile(unc_raw, 95)))
+            if np.isfinite(lo) and np.isfinite(hi) and hi > lo:
+                unc = np.clip((unc_raw - lo) / (hi - lo), 0.0, 1.0)
+                u = (0.7 + 0.6 * unc).astype(np.float32)
+            else:
+                u = np.ones(len(X_df), dtype=np.float32)
+        else:
+            lgb_signed = np.zeros(len(X_df), dtype=np.float32)
+            u = np.ones(len(X_df), dtype=np.float32)
+        lam = float(self._diag.get("lambda_clf", 0.3))
+        f = np.clip(p_r + lam * lgb_signed * u, 1e-4, 1 - 1e-4)
+        if self.calibrator is not None:
+            f = np.clip(self.calibrator.predict(f), 1e-4, 1 - 1e-4)
+        return np.column_stack([1.0 - f, f]).astype(np.float32)
+
+    def predict(self, X):
+        return self.predict_proba(X)[:, 1]
+
+    def predict_uncertainty_features(self, X):
+        n = len(X)
+        X_df = pd.DataFrame(X).replace([np.inf, -np.inf], 0.0).fillna(0.0)
+        lf = [c for c in self._diag.get("lgbm_features", []) if c in X_df.columns]
+        out = {}
+        if self.lgbm_model is not None and len(lf) > 0:
+            p3 = self.lgbm_model.predict_proba(
+                X_df.reindex(columns=lf, fill_value=0.0)
+            ).astype(np.float32)
+            eps = 1e-9
+            ent = -np.sum(p3 * np.log(np.clip(p3, eps, 1.0)), axis=1) / np.log(3.0)
+            extreme = p3[:, 0] + p3[:, 2]
+            top2 = np.partition(p3, -2, axis=1)[:, -2:]
+            margin = top2[:, 1] - top2[:, 0]
+            unc_raw = 0.5 * (1.0 - ent) + 0.25 * extreme + 0.25 * margin
+            lo = float(self._diag.get("unc_lo", np.nanpercentile(unc_raw, 5)))
+            hi = float(self._diag.get("unc_hi", np.nanpercentile(unc_raw, 95)))
+            unc = (
+                (0.7 + 0.6 * np.clip((unc_raw - lo) / max(hi - lo, 1e-12), 0.0, 1.0))
+                if hi > lo
+                else np.ones(n, dtype=np.float32)
+            )
+            out["entropy"] = ent.astype(np.float32)
+            out["extreme_mass"] = extreme.astype(np.float32)
+            out["margin"] = margin.astype(np.float32)
+            out["uncertainty"] = np.asarray(unc, dtype=np.float32)
+        else:
+            out["entropy"] = np.full(n, np.nan, dtype=np.float32)
+            out["extreme_mass"] = np.full(n, np.nan, dtype=np.float32)
+            out["margin"] = np.full(n, np.nan, dtype=np.float32)
+            out["uncertainty"] = np.ones(n, dtype=np.float32)
+        out["prefix_std"] = np.full(
+            n, np.nanstd(self._diag.get("final", np.zeros(n))), dtype=np.float32
+        )
+        out["leaf_support_q25"] = np.full(n, np.nan, dtype=np.float32)
+        out["leaf_target_iqr_mean"] = np.full(n, np.nan, dtype=np.float32)
+        return out
+
+
+def save_weak_meta_outputs(
+    *,
+    out_dir: str,
+    base_clf_pred: np.ndarray,
+    base_reg_pred: np.ndarray,
+    clf_model: WeakResidualMetaClassifier,
+    reg_model: WeakResidualMetaRegressor,
+) -> None:
+    os.makedirs(out_dir, exist_ok=True)
+    clf_final = np.asarray(clf_model._diag.get("final"), dtype=np.float32)
+    reg_final = np.asarray(reg_model._diag.get("final"), dtype=np.float32)
+    df = pd.DataFrame(
+        {
+            "base_clf_pred": np.asarray(base_clf_pred, dtype=np.float32),
+            "base_reg_pred": np.asarray(base_reg_pred, dtype=np.float32),
+            "meta_clf_ridge_pred": np.asarray(
+                clf_model._diag.get("ridge_prob_correct"), dtype=np.float32
+            ),
+            "meta_clf_lgbm_pred": np.asarray(
+                clf_model._diag.get("meta_clf_lgbm_adj"), dtype=np.float32
+            ),
+            "meta_clf_uncertainty": np.asarray(
+                clf_model._diag.get("meta_clf_uncertainty"), dtype=np.float32
+            ),
+            "meta_clf_final_raw": np.asarray(
+                clf_model._diag.get("meta_clf_final_raw"), dtype=np.float32
+            ),
+            "meta_clf_final": clf_final,
+            "meta_reg_ridge_pred": np.asarray(
+                reg_model._diag.get("ridge_pred"), dtype=np.float32
+            ),
+            "meta_reg_lgbm_pred": np.asarray(
+                reg_model._diag.get("lgbm_pred"), dtype=np.float32
+            ),
+            "meta_reg_uncertainty": np.asarray(
+                reg_model._diag.get("meta_reg_uncertainty"), dtype=np.float32
+            ),
+            "meta_reg_final": reg_final,
+        }
+    )
+    df["score_base_x_meta_clf"] = _ranknorm(
+        df["base_clf_pred"].values * df["meta_clf_final"].values
+    )
+    # Assumes meta_reg_final is a correction on the same return scale as base_reg_pred.
+    df["score_base_plus_meta_reg"] = _ranknorm(
+        df["base_reg_pred"].values + df["meta_reg_final"].values
+    )
+    df["score_combo_add"] = _ranknorm(
+        0.5 * df["score_base_x_meta_clf"] + 0.5 * df["score_base_plus_meta_reg"]
+    )
+    df["score_combo_mult"] = _ranknorm(
+        df["score_base_x_meta_clf"] * df["score_base_plus_meta_reg"]
+    )
+    df.to_parquet(
+        os.path.join(out_dir, "weak_residual_meta_outputs.parquet"), index=False
+    )
+
+    diag = pd.DataFrame(
+        {
+            "meta_clf_entropy": clf_model._diag.get("meta_clf_entropy"),
+            "meta_clf_extreme_mass": clf_model._diag.get("meta_clf_extreme_mass"),
+            "meta_clf_margin": clf_model._diag.get("meta_clf_margin"),
+            "meta_reg_leaf_var": reg_model._diag.get("meta_reg_leaf_var"),
+            "meta_reg_leaf_count": reg_model._diag.get("meta_reg_leaf_count"),
+            "meta_reg_support_factor": reg_model._diag.get("meta_reg_support_factor"),
+        }
+    )
+    diag.to_parquet(
+        os.path.join(out_dir, "weak_residual_meta_diagnostics.parquet"), index=False
+    )


### PR DESCRIPTION
### Motivation
- Provide lightweight "weak-residual" meta models (classifier and regressor) to augment base meta predictions with small LGBM corrections and calibrated uncertainty diagnostics for downstream use. 
- Introduce a Ridge-on-LGBM stacking candidate to generate leaf-feature representations and a compact linear combiner for higher-quality, explainable meta features. 
- Wire weak-residual outputs into the existing meta training/export pipeline so weak-meta diagnostics travel with canonical `meta_oof` artifacts for downstream consumers.

### Description
- Adds `extreme_price_movements/weak_residual_meta_learner.py` implementing `WeakResidualMetaClassifier`, `WeakResidualMetaRegressor`, feature selection/pruning utilities, cross-fit diagnostics, uncertainty estimation from LGBM leaf statistics, and `save_weak_meta_outputs` to persist combined diagnostics. 
- Adds `extreme_price_movements/ridge_on_lgbm.py` implementing a pipeline that fits several LGBM leaf-bundles, one-hot encodes leaves, prunes features via cross-validated elastic-net/logistic selectors, and fits a final `RidgeClassifier` using stacked leaf/raw features. 
- Integrates weak-meta components into `train_meta_models_from_artifacts` in `extreme_price_movements/training.py` by replacing some `MetaClassifierModel`/`MetaModel` instantiations with `WeakResidualMetaClassifier`/`WeakResidualMetaRegressor`, passing `base_oof_pred`, `y_true_clf`, and `base_threshold` into the classifier fit call, and calling `save_weak_meta_outputs` to dump sidecar artifacts. 
- Appends weak-residual diagnostic fields into exported `meta_oof` parquet files via `_append_weak_meta_oof_fields` and writes universal per-head prediction diagnostics (`diag_mean_pred`, `diag_std_pred`). 

### Testing
- No automated test suite changes were included in this rollout and no CI tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ec63edb8832f845ba4386393d26a)